### PR TITLE
[Injimob 2265] make changes to support presentation_definition_uri and return logo_url as part of client_metadata

### DIFF
--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/OpenID4VP.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/OpenID4VP.kt
@@ -31,7 +31,7 @@ class OpenID4VP(private val traceabilityId: String) {
         encodedAuthorizationRequest: String, trustedVerifiers: List<Verifier>
     ): AuthorizationRequest {
         try {
-            Logger.setTraceability(traceabilityId)
+            Logger.setTraceabilityId(traceabilityId)
             authorizationRequest = AuthorizationRequest.validateAndGetAuthorizationRequest(
                 encodedAuthorizationRequest, ::setResponseUri
             )
@@ -82,7 +82,7 @@ class OpenID4VP(private val traceabilityId: String) {
             } catch (exception: Exception) {
                 Logger.error(
                     logTag,
-                    Exception("Unexpected error occurred while sending the error to verifier.")
+                    Exception("Unexpected error occurred while sending the error to verifier: ${exception.message}")
                 )
             }
         }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/OpenID4VP.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/OpenID4VP.kt
@@ -8,7 +8,8 @@ import io.mosip.openID4VP.authorizationResponse.AuthorizationResponse
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.dto.VPResponseMetadata
 import io.mosip.openID4VP.dto.Verifier
-import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHttpPostRequest
+import io.mosip.openID4VP.networkManager.HTTP_METHOD
+import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
 
 private val logTag = Logger.getLogTag(AuthorizationResponse::class.simpleName!!)
 class OpenID4VP(private val traceabilityId: String) {
@@ -76,8 +77,8 @@ class OpenID4VP(private val traceabilityId: String) {
     fun sendErrorToVerifier(exception: Exception) {
         responseUri?.let {
             try {
-                sendHttpPostRequest(
-                    it, mapOf("error" to exception.message!!)
+                sendHTTPRequest(
+                    url = it, method = HTTP_METHOD.POST,mapOf("error" to exception.message!!)
                 )
             } catch (exception: Exception) {
                 Logger.error(

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authenticationResponse/AuthenticationResponse.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authenticationResponse/AuthenticationResponse.kt
@@ -4,11 +4,12 @@ import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest
 import io.mosip.openID4VP.authorizationRequest.ClientMetadata
 import io.mosip.openID4VP.authorizationRequest.ClientMetadataSerializer
 import io.mosip.openID4VP.authorizationRequest.deserializeAndValidate
-import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.PresentationDefinition
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.PresentationDefinitionSerializer
+import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.dto.Verifier
 
+private val className = AuthenticationResponse::class.simpleName!!
 class AuthenticationResponse {
     companion object {
         fun validateAuthorizationRequestPartially(
@@ -39,7 +40,11 @@ class AuthenticationResponse {
                 } catch (e: Exception) {
                     throw e
                 }
-            } ?: run { throw AuthorizationRequestExceptions.InvalidVerifierClientID() }
+            } ?: run {
+                throw Logger.handleException(
+                    exceptionType = "InvalidVerifierClientID", className = className
+                )
+            }
         }
 
         private fun validateVerifier(

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequest.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequest.kt
@@ -3,16 +3,16 @@ package io.mosip.openID4VP.authorizationRequest
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.PresentationDefinition
 import io.mosip.openID4VP.common.Decoder
 import io.mosip.openID4VP.common.Logger
+import io.mosip.openID4VP.common.validateField
 import io.mosip.openID4VP.networkManager.HTTP_METHOD
 import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
-import validateField
 import java.net.URI
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
-private val logTag = Logger.getLogTag(AuthorizationRequest::class.simpleName!!)
 private val className = AuthorizationRequest::class.simpleName!!
+private val logTag = Logger.getLogTag(className)
 
 data class AuthorizationRequest(
     val clientId: String,

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequest.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequest.kt
@@ -117,6 +117,7 @@ data class AuthorizationRequest(
                             exceptionType = "InvalidInput",
                             fieldPath = listOf("presentation_definition"),
                             className = className,
+                            fieldType = "String"
                         )
                     }
                     presentationDefinition =
@@ -125,14 +126,10 @@ data class AuthorizationRequest(
 
                 hasPresentationDefinitionUri -> {
                     try {
-                        val value = params["presentation_definition_uri"]
-                        require(value != "null" && validateField(value, "String")) {
-                            throw Logger.handleException(
-                                exceptionType = "InvalidInput",
-                                fieldPath = listOf("presentation_definition_uri"),
-                                className = className,
-                            )
-                        }
+                        validateRootFieldInvalidScenario(
+                            "presentation_definition_uri",
+                            params["presentation_definition_uri"]
+                        )
                         presentationDefinition =
                             sendHTTPRequest(
                                 url = params["presentation_definition_uri"]!!,
@@ -157,29 +154,9 @@ data class AuthorizationRequest(
         private fun validateQueryParams(
             params: MutableMap<String, String>, setResponseUri: (String) -> Unit
         ) {
-            val hasResponseUri = params.containsKey("response_uri")
-            if (!hasResponseUri) {
-                throw Logger.handleException(
-                    exceptionType = "MissingInput",
-                    fieldPath = listOf("response_uri"),
-                    className = className
-                )
-            }
-            val responseUri = params["response_uri"]
-            require(
-                responseUri != null && validateField(
-                    responseUri,
-                    "String"
-                )
-            ) {
-                throw Logger.handleException(
-                    exceptionType = "InvalidInput",
-                    fieldPath = listOf("response_uri"),
-                    className = className,
-                    fieldType = "String"
-                )
-            }
-            setResponseUri(responseUri)
+            validateRootFieldMissingScenario(params, "response_uri")
+            validateRootFieldInvalidScenario("response_uri", params["response_uri"])
+            setResponseUri(params["response_uri"]!!)
 
             val requiredRequestParams = mutableListOf(
                 "presentation_definition",
@@ -197,23 +174,8 @@ data class AuthorizationRequest(
                         throw exception
                     }
                 }
-                val hasParam = params.containsKey(param)
-                if (!hasParam) {
-                    throw Logger.handleException(
-                        exceptionType = "MissingInput",
-                        fieldPath = listOf(param),
-                        className = className
-                    )
-                }
-                val value = params[param]
-                require(value != "null" && validateField(value, "String")) {
-                    throw Logger.handleException(
-                        exceptionType = "InvalidInput",
-                        fieldPath = listOf(param),
-                        className = className,
-                        fieldType = "String"
-                    )
-                }
+                validateRootFieldMissingScenario(params, param)
+                validateRootFieldInvalidScenario(param, params[param])
             }
 
             val optionalRequestParams = mutableListOf("client_metadata")
@@ -242,6 +204,31 @@ data class AuthorizationRequest(
                 state = params["state"]!!,
                 clientMetadata = params["client_metadata"],
             )
+        }
+
+        private fun validateRootFieldMissingScenario(
+            params: MutableMap<String, String>,
+            param: String
+        ) {
+            val hasParam = params.containsKey(param)
+            if (!hasParam) {
+                throw Logger.handleException(
+                    exceptionType = "MissingInput",
+                    fieldPath = listOf(param),
+                    className = className
+                )
+            }
+        }
+
+        private fun validateRootFieldInvalidScenario(param: String, value: String?) {
+            require(value != "null" && validateField(value, "String")) {
+                throw Logger.handleException(
+                    exceptionType = "InvalidInput",
+                    fieldPath = listOf(param),
+                    className = className,
+                    fieldType = "String"
+                )
+            }
         }
     }
 }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequest.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequest.kt
@@ -4,7 +4,8 @@ import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExc
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.PresentationDefinition
 import io.mosip.openID4VP.common.Decoder
 import io.mosip.openID4VP.common.Logger
-import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHttpGetRequest
+import io.mosip.openID4VP.networkManager.HTTP_METHOD
+import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
 import java.net.URI
 import java.net.URLDecoder
 import java.net.URLEncoder
@@ -96,7 +97,6 @@ data class AuthorizationRequest(
         }
 
         private fun fetchPresentationDefinition(params: Map<String, String>): String {
-            val exception: Exception
             val hasPresentationDefinition = params.containsKey("presentation_definition")
             val hasPresentationDefinitionUri = params.containsKey("presentation_definition_uri")
             var presentationDefinition = ""
@@ -116,7 +116,10 @@ data class AuthorizationRequest(
                 hasPresentationDefinitionUri -> {
                     try {
                         presentationDefinition =
-                            sendHttpGetRequest(params["presentation_definition_uri"]!!)
+                            sendHTTPRequest(
+                                url = params["presentation_definition_uri"]!!,
+                                method = HTTP_METHOD.GET
+                            )
                     } catch (exception: Exception) {
                         throw exception
                     }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequest.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequest.kt
@@ -1,12 +1,11 @@
 package io.mosip.openID4VP.authorizationRequest
 
-import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.PresentationDefinition
 import io.mosip.openID4VP.common.Decoder
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.networkManager.HTTP_METHOD
 import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
-import isNeitherNullNorEmpty
+import validateField
 import java.net.URI
 import java.net.URLDecoder
 import java.net.URLEncoder
@@ -116,11 +115,12 @@ data class AuthorizationRequest(
                         fieldPath = listOf("presentation_definition"),
                         className = className
                     )
-                    require(isNeitherNullNorEmpty(value)) {
+                    require(validateField(value, value::class.simpleName)) {
                         throw Logger.handleException(
                             exceptionType = "InvalidInput",
                             fieldPath = listOf("presentation_definition"),
-                            className = className
+                            className = className,
+                            fieldType = value::class.simpleName
                         )
                     }
                     presentationDefinition =
@@ -135,11 +135,12 @@ data class AuthorizationRequest(
                                 fieldPath = listOf("presentation_definition_uri"),
                                 className = className
                             )
-                        require(isNeitherNullNorEmpty(value)) {
+                        require(validateField(value, value::class.simpleName)) {
                             throw Logger.handleException(
                                 exceptionType = "InvalidInput",
                                 fieldPath = listOf("presentation_definition_uri"),
-                                className = className
+                                className = className,
+                                fieldType = value::class.simpleName
                             )
                         }
                         presentationDefinition =
@@ -152,7 +153,7 @@ data class AuthorizationRequest(
                     }
                 }
 
-                !hasPresentationDefinitionUri -> {
+                else -> {
                     throw Logger.handleException(
                         exceptionType = "InvalidQueryParams",
                         message = "Either presentation_definition or presentation_definition_uri request param must be present",
@@ -173,11 +174,12 @@ data class AuthorizationRequest(
                     fieldPath = listOf("response_uri"),
                     className = className
                 )
-            } else if (!isNeitherNullNorEmpty(responseUri)) {
+            } else if (!validateField(responseUri,responseUri::class.simpleName)) {
                 throw Logger.handleException(
                     exceptionType = "InvalidInput",
                     fieldPath = listOf("response_uri"),
-                    className = className
+                    className = className,
+                    fieldType = responseUri::class.simpleName
                 )
             } else {
                 setResponseUri(responseUri)
@@ -204,11 +206,12 @@ data class AuthorizationRequest(
                     fieldPath = listOf(param),
                     className = className
                 )
-                require(isNeitherNullNorEmpty(value)) {
+                require(validateField(value,value::class.simpleName)) {
                     throw Logger.handleException(
                         exceptionType = "InvalidInput",
                         fieldPath = listOf(param),
-                        className = className
+                        className = className,
+                        fieldType = value::class.simpleName
                     )
                 }
             }
@@ -217,7 +220,12 @@ data class AuthorizationRequest(
             optionalRequestParams.forEach { param ->
                 params[param]?.let { value ->
                     require(value.isNotEmpty()) {
-                        throw AuthorizationRequestExceptions.InvalidInput(param)
+                        throw Logger.handleException(
+                            exceptionType = "InvalidInput",
+                            fieldPath = listOf("client_metadata"),
+                            className = className,
+                            fieldType = value::class.simpleName
+                        )
                     }
                 }
             }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequest.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequest.kt
@@ -110,17 +110,13 @@ data class AuthorizationRequest(
                 }
 
                 hasPresentationDefinition -> {
-                    val value = params["presentation_definition"] ?: throw Logger.handleException(
-                        exceptionType = "MissingInput",
-                        fieldPath = listOf("presentation_definition"),
-                        className = className
-                    )
-                    require(validateField(value, value::class.simpleName)) {
+                    val value = params["presentation_definition"]
+
+                    require(value != "null" && validateField(value, "String")) {
                         throw Logger.handleException(
                             exceptionType = "InvalidInput",
                             fieldPath = listOf("presentation_definition"),
                             className = className,
-                            fieldType = value::class.simpleName
                         )
                     }
                     presentationDefinition =
@@ -129,18 +125,12 @@ data class AuthorizationRequest(
 
                 hasPresentationDefinitionUri -> {
                     try {
-                        val value =
-                            params["presentation_definition_uri"] ?: throw Logger.handleException(
-                                exceptionType = "MissingInput",
-                                fieldPath = listOf("presentation_definition_uri"),
-                                className = className
-                            )
-                        require(validateField(value, value::class.simpleName)) {
+                        val value = params["presentation_definition_uri"]
+                        require(value != "null" && validateField(value, "String")) {
                             throw Logger.handleException(
                                 exceptionType = "InvalidInput",
                                 fieldPath = listOf("presentation_definition_uri"),
                                 className = className,
-                                fieldType = value::class.simpleName
                             )
                         }
                         presentationDefinition =
@@ -167,23 +157,29 @@ data class AuthorizationRequest(
         private fun validateQueryParams(
             params: MutableMap<String, String>, setResponseUri: (String) -> Unit
         ) {
-            val responseUri = params["response_uri"]
-            if (responseUri == null) {
+            val hasResponseUri = params.containsKey("response_uri")
+            if (!hasResponseUri) {
                 throw Logger.handleException(
                     exceptionType = "MissingInput",
                     fieldPath = listOf("response_uri"),
                     className = className
                 )
-            } else if (!validateField(responseUri,responseUri::class.simpleName)) {
+            }
+            val responseUri = params["response_uri"]
+            require(
+                responseUri != null && validateField(
+                    responseUri,
+                    "String"
+                )
+            ) {
                 throw Logger.handleException(
                     exceptionType = "InvalidInput",
                     fieldPath = listOf("response_uri"),
                     className = className,
-                    fieldType = responseUri::class.simpleName
+                    fieldType = "String"
                 )
-            } else {
-                setResponseUri(responseUri)
             }
+            setResponseUri(responseUri)
 
             val requiredRequestParams = mutableListOf(
                 "presentation_definition",
@@ -201,17 +197,21 @@ data class AuthorizationRequest(
                         throw exception
                     }
                 }
-                val value = params[param] ?: throw Logger.handleException(
-                    exceptionType = "MissingInput",
-                    fieldPath = listOf(param),
-                    className = className
-                )
-                require(validateField(value,value::class.simpleName)) {
+                val hasParam = params.containsKey(param)
+                if (!hasParam) {
+                    throw Logger.handleException(
+                        exceptionType = "MissingInput",
+                        fieldPath = listOf(param),
+                        className = className
+                    )
+                }
+                val value = params[param]
+                require(value != "null" && validateField(value, "String")) {
                     throw Logger.handleException(
                         exceptionType = "InvalidInput",
                         fieldPath = listOf(param),
                         className = className,
-                        fieldType = value::class.simpleName
+                        fieldType = "String"
                     )
                 }
             }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/ClientMetadata.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/ClientMetadata.kt
@@ -1,7 +1,7 @@
 package io.mosip.openID4VP.authorizationRequest
 
-import FieldDeserializer
 import Generated
+import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.common.Logger
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/ClientMetadata.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/ClientMetadata.kt
@@ -37,7 +37,11 @@ object ClientMetadataSerializer : KSerializer<ClientMetadata> {
 		builtInDecoder.endStructure(descriptor)
 
 		requireNotNull(name) {
-			throw Logger.handleException("MissingInput", "client_metadata", "name", className)
+			throw Logger.handleException(
+				exceptionType = "MissingInput",
+				fieldPath = listOf("client_metadata", "name"),
+				className = className
+			)
 		}
 		return ClientMetadata(name = name, logoUrl = logoUrl)
 	}
@@ -56,15 +60,18 @@ class ClientMetadata(val name: String, @SerialName("logo_url") val logoUrl: Stri
 	override fun validate() {
 		try {
 			require(isNeitherNullNorEmpty(name)) {
-				throw Logger.handleException("InvalidInput", "client_metadata", "name", className)
+				throw Logger.handleException(
+					exceptionType = "InvalidInput",
+					fieldPath = listOf("client_metadata", "name"),
+					className = className
+				)
 			}
 			logoUrl?.let {
 				require(isNeitherNullNorEmpty(logoUrl)) {
 					throw Logger.handleException(
-						"InvalidInput",
-						"client_metadata",
-						"logo_url",
-						className
+						exceptionType = "InvalidInput",
+						fieldPath = listOf("client_metadata", "logo_url"),
+						className = className
 					)
 				}
 			}

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/ClientMetadata.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/ClientMetadata.kt
@@ -50,6 +50,7 @@ object ClientMetadataSerializer : KSerializer<ClientMetadata> {
 	override fun serialize(encoder: Encoder, value: ClientMetadata) {
 		val builtInEncoder = encoder.beginStructure(descriptor)
 		builtInEncoder.encodeStringElement(descriptor, 0, value.name)
+		value.logoUrl?.let { builtInEncoder.encodeStringElement(descriptor, 1, it) }
 		builtInEncoder.endStructure(descriptor)
 	}
 }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/ClientMetadata.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/ClientMetadata.kt
@@ -3,6 +3,7 @@ package io.mosip.openID4VP.authorizationRequest
 import Generated
 import io.mosip.openID4VP.common.Logger
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
@@ -16,16 +17,19 @@ private val className = ClientMetadata::class.simpleName!!
 object ClientMetadataSerializer : KSerializer<ClientMetadata> {
 	override val descriptor: SerialDescriptor = buildClassSerialDescriptor("ClientMetadata") {
 		element<String>("name")
+		element<String>("logo_url", isOptional = true)
 	}
 
 	override fun deserialize(decoder: Decoder): ClientMetadata {
 		val builtInDecoder = decoder.beginStructure(descriptor)
 		var name: String? = null
+		var logoUrl: String? = null
 
 		loop@ while (true) {
 			when (builtInDecoder.decodeElementIndex(descriptor)) {
 				CompositeDecoder.DECODE_DONE -> break@loop
 				0 -> name = builtInDecoder.decodeStringElement(descriptor, 0)
+				1 -> logoUrl = builtInDecoder.decodeStringElement(descriptor, 1)
 			}
 		}
 
@@ -34,7 +38,7 @@ object ClientMetadataSerializer : KSerializer<ClientMetadata> {
 		requireNotNull(name) {
 			throw Logger.handleException("MissingInput", "client_metadata", "name", className)
 		}
-		return ClientMetadata(name = name)
+		return ClientMetadata(name = name, logoUrl = logoUrl)
 	}
 
 	@Generated
@@ -46,11 +50,22 @@ object ClientMetadataSerializer : KSerializer<ClientMetadata> {
 }
 
 @Serializable(with = ClientMetadataSerializer::class)
-class ClientMetadata(val name: String) : Validatable {
+class ClientMetadata(val name: String, @SerialName("logo_url") val logoUrl: String?) :
+	Validatable {
 	override fun validate() {
 		try {
 			require(name.isNotEmpty()) {
 				throw Logger.handleException("InvalidInput", "client_metadata", "name", className)
+			}
+			logoUrl?.let {
+				require(logoUrl.isNotEmpty()) {
+					throw Logger.handleException(
+						"InvalidInput",
+						"client_metadata",
+						"logo_url",
+						className
+					)
+				}
 			}
 		} catch (exception: Exception) {
 			throw exception

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/ClientMetadata.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/ClientMetadata.kt
@@ -2,6 +2,7 @@ package io.mosip.openID4VP.authorizationRequest
 
 import Generated
 import io.mosip.openID4VP.common.Logger
+import isNeitherNullNorEmpty
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -54,11 +55,11 @@ class ClientMetadata(val name: String, @SerialName("logo_url") val logoUrl: Stri
 	Validatable {
 	override fun validate() {
 		try {
-			require(name.isNotEmpty()) {
+			require(isNeitherNullNorEmpty(name)) {
 				throw Logger.handleException("InvalidInput", "client_metadata", "name", className)
 			}
 			logoUrl?.let {
-				require(logoUrl.isNotEmpty()) {
+				require(isNeitherNullNorEmpty(logoUrl)) {
 					throw Logger.handleException(
 						"InvalidInput",
 						"client_metadata",

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/ClientMetadata.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/ClientMetadata.kt
@@ -18,8 +18,8 @@ private val className = ClientMetadata::class.simpleName!!
 
 object ClientMetadataSerializer : KSerializer<ClientMetadata> {
 	override val descriptor: SerialDescriptor = buildClassSerialDescriptor("ClientMetadata") {
-		element<String>("name")
-		element<String>("logo_url", isOptional = true)
+		element<String>("client_name", isOptional = true)
+		element<String>("logo_uri", isOptional = true)
 	}
 
 	override fun deserialize(decoder: Decoder): ClientMetadata {
@@ -40,25 +40,34 @@ object ClientMetadataSerializer : KSerializer<ClientMetadata> {
 			parentField = "client_metadata"
 		)
 
-		val name: String? =
-			deserializer.deserializeField(key = "name", fieldType = "String", isMandatory = true)
-		val logoUrl: String? =
-			deserializer.deserializeField(key = "logo_url", fieldType = "String")
+		val clientName: String? =
+			deserializer.deserializeField(key = "client_name", fieldType = "String")
+		val logoUri: String? =
+			deserializer.deserializeField(key = "logo_uri", fieldType = "String")
 
-		return ClientMetadata(name = name!!, logoUrl = logoUrl)
+		return ClientMetadata(clientName = clientName, logoUri = logoUri)
 	}
 
 	@Generated
 	override fun serialize(encoder: Encoder, value: ClientMetadata) {
 		val builtInEncoder = encoder.beginStructure(descriptor)
-		builtInEncoder.encodeStringElement(descriptor, 0, value.name)
-		value.logoUrl?.let { builtInEncoder.encodeStringElement(descriptor, 1, it) }
+		value.clientName?.let {
+			builtInEncoder.encodeStringElement(
+				descriptor,
+				0,
+				value.clientName
+			)
+		}
+		value.logoUri?.let { builtInEncoder.encodeStringElement(descriptor, 1, it) }
 		builtInEncoder.endStructure(descriptor)
 	}
 }
 
 @Serializable(with = ClientMetadataSerializer::class)
-class ClientMetadata(val name: String, @SerialName("logo_url") val logoUrl: String?) :
+class ClientMetadata(
+	@SerialName("client_name") val clientName: String?,
+	@SerialName("logo_uri") val logoUri: String?
+) :
 	Validatable {
 	override fun validate() {
 	}

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/exception/AuthorizationRequestExceptions.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/exception/AuthorizationRequestExceptions.kt
@@ -14,7 +14,7 @@ sealed class AuthorizationRequestExceptions {
         Exception(
             "Invalid Input: ${
                 when (fieldType) {
-                    "String" -> "$fieldPath value cannot be empty string, null or null string"
+                    "String" -> "$fieldPath value cannot be empty string or null"
                     "Boolean" -> "$fieldPath value must be either true or false"
                     else -> "$fieldPath value cannot be empty or null"
                 }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/exception/AuthorizationRequestExceptions.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/exception/AuthorizationRequestExceptions.kt
@@ -11,7 +11,7 @@ sealed class AuthorizationRequestExceptions {
     class MissingInput(fieldPath: String) : Exception("Missing Input: $fieldPath param is required")
 
     class InvalidInput(fieldPath: String) :
-        Exception("Invalid Input: $fieldPath value cannot be empty or null")
+        Exception("Invalid Input: $fieldPath value cannot be empty string, null or null string")
 
     class InvalidInputPattern(fieldPath: String) :
         Exception("Invalid Input Pattern: $fieldPath pattern is not matching with OpenId4VP specification")

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/exception/AuthorizationRequestExceptions.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/exception/AuthorizationRequestExceptions.kt
@@ -8,16 +8,19 @@ sealed class AuthorizationRequestExceptions {
 
     class DecodingException(message: String) : Exception(message)
 
-    class MissingInput(fieldName: String) : Exception("Missing Input: $fieldName param is required")
+    class MissingInput(fieldPath: String) : Exception("Missing Input: $fieldPath param is required")
 
-    class InvalidInput(fieldName: String) :
-        Exception("Invalid Input: $fieldName value cannot be empty or null")
+    class InvalidInput(fieldPath: String) :
+        Exception("Invalid Input: $fieldPath value cannot be empty or null")
 
-    class InvalidInputPattern(fieldName: String) :
-        Exception("Invalid Input Pattern: $fieldName pattern is not matching with OpenId4VP specification")
+    class InvalidInputPattern(fieldPath: String) :
+        Exception("Invalid Input Pattern: $fieldPath pattern is not matching with OpenId4VP specification")
+
+    class JsonEncodingFailed(fieldPath: String, message: String) :
+        Exception("Json encoding failed for $fieldPath due to this error: $message")
 
     class InvalidLimitDisclosure :
-        Exception("Invalid Input: limit_disclosure value should be either required or preferred")
+        Exception("Invalid Input: constraints->limit_disclosure value should be either required or preferred")
 
     class InvalidQueryParams(message: String) : Exception(message)
 }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/exception/AuthorizationRequestExceptions.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/exception/AuthorizationRequestExceptions.kt
@@ -10,14 +10,25 @@ sealed class AuthorizationRequestExceptions {
 
     class MissingInput(fieldPath: String) : Exception("Missing Input: $fieldPath param is required")
 
-    class InvalidInput(fieldPath: String) :
-        Exception("Invalid Input: $fieldPath value cannot be empty string, null or null string")
+    class InvalidInput(fieldPath: String, fieldType: Any?) :
+        Exception(
+            "Invalid Input: ${
+                when (fieldType) {
+                    "String" -> "$fieldPath value cannot be empty string, null or null string"
+                    "Boolean" -> "$fieldPath value must be either true or false"
+                    else -> "$fieldPath value cannot be empty or null"
+                }
+            }"
+        )
 
     class InvalidInputPattern(fieldPath: String) :
         Exception("Invalid Input Pattern: $fieldPath pattern is not matching with OpenId4VP specification")
 
     class JsonEncodingFailed(fieldPath: String, message: String) :
         Exception("Json encoding failed for $fieldPath due to this error: $message")
+
+    class DeserializationFailure(fieldPath: String, message: String) :
+        Exception("Deserializing for $fieldPath failed due to this error: $message")
 
     class InvalidLimitDisclosure :
         Exception("Invalid Input: constraints->limit_disclosure value should be either required or preferred")

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Constraints.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Constraints.kt
@@ -42,7 +42,7 @@ object ConstraintsSerializer : KSerializer<Constraints> {
 
 		val fields: List<Fields>? = deserializer.deserializeField(
 			key = "fields",
-			fieldType = "List<*>",
+			fieldType = "List<Fields>",
 			deserializer = ListSerializer(Fields.serializer()),
 		)
 		val limitDisclosure: String? = deserializer.deserializeField(

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Constraints.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Constraints.kt
@@ -3,6 +3,7 @@ package io.mosip.openID4VP.authorizationRequest.presentationDefinition
 import Generated
 import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
 import io.mosip.openID4VP.common.Logger
+import isNeitherNullNorEmpty
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -15,7 +16,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
 private val logTag = Logger.getLogTag(Constraints::class.simpleName!!)
-
+private val className = Constraints::class.simpleName!!
 object ConstraintsSerializer : KSerializer<Constraints> {
 	override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Constraints") {
 		element<List<Fields>>("fields", isOptional = true)
@@ -73,10 +74,17 @@ class Constraints(
 			}
 
 			limitDisclosure?.let {
+				require(isNeitherNullNorEmpty(limitDisclosure)) {
+					throw Logger.handleException(
+						"InvalidInput", "constraints", "limit_disclosure",
+						className
+					)
+				}
+
 				LimitDisclosure.values().firstOrNull { it.value == limitDisclosure }
 					?: throw AuthorizationRequestExceptions.InvalidLimitDisclosure()
 			}
-		} catch (exception: AuthorizationRequestExceptions.InvalidInput) {
+		} catch (exception: Exception) {
 			Logger.error(logTag, exception)
 			throw exception
 		}

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Constraints.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Constraints.kt
@@ -1,7 +1,7 @@
 package io.mosip.openID4VP.authorizationRequest.presentationDefinition
 
-import FieldDeserializer
 import Generated
+import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.common.Logger
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -15,7 +15,6 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.jsonObject
 
-private val logTag = Logger.getLogTag(Constraints::class.simpleName!!)
 private val className = Constraints::class.simpleName!!
 object ConstraintsSerializer : KSerializer<Constraints> {
 	override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Constraints") {

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Constraints.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Constraints.kt
@@ -1,7 +1,6 @@
 package io.mosip.openID4VP.authorizationRequest.presentationDefinition
 
 import Generated
-import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
 import io.mosip.openID4VP.common.Logger
 import isNeitherNullNorEmpty
 import kotlinx.serialization.KSerializer
@@ -76,13 +75,17 @@ class Constraints(
 			limitDisclosure?.let {
 				require(isNeitherNullNorEmpty(limitDisclosure)) {
 					throw Logger.handleException(
-						"InvalidInput", "constraints", "limit_disclosure",
-						className
+						exceptionType = "InvalidInput",
+						fieldPath = listOf("constraints", "limit_disclosure"),
+						className = className
 					)
 				}
 
 				LimitDisclosure.values().firstOrNull { it.value == limitDisclosure }
-					?: throw AuthorizationRequestExceptions.InvalidLimitDisclosure()
+					?: throw Logger.handleException(
+						exceptionType = "InvalidLimitDisclosure",
+						className = className
+					)
 			}
 		} catch (exception: Exception) {
 			Logger.error(logTag, exception)

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Fields.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Fields.kt
@@ -1,7 +1,7 @@
 package io.mosip.openID4VP.authorizationRequest.presentationDefinition
 
-import FieldDeserializer
 import Generated
+import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.common.Logger
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Fields.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Fields.kt
@@ -1,7 +1,6 @@
 package io.mosip.openID4VP.authorizationRequest.presentationDefinition
 
 import Generated
-import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
 import io.mosip.openID4VP.common.Logger
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Fields.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Fields.kt
@@ -54,7 +54,11 @@ object FieldsSerializer : KSerializer<Fields> {
 		builtInDecoder.endStructure(descriptor)
 
 		requireNotNull(path) {
-			throw Logger.handleException("MissingInput", "fields", "path", className)
+			throw Logger.handleException(
+				exceptionType = "MissingInput",
+				fieldPath = listOf("fields", "path"),
+				className = className
+			)
 		}
 
 		return Fields(
@@ -104,7 +108,11 @@ class Fields(
 	fun validate() {
 		try {
 			require(path.isNotEmpty()) {
-				throw Logger.handleException("InvalidInput", "fields", "path", className)
+				throw Logger.handleException(
+					exceptionType = "InvalidInput",
+					fieldPath = listOf("fields", "path"),
+					className = className
+				)
 			}
 
 			val pathPrefixes = listOf("$.", "$[")
@@ -112,8 +120,9 @@ class Fields(
 				val isNotValidPrefix = !(pathPrefixes.any { p.startsWith(it) })
 				if (isNotValidPrefix) {
 					throw Logger.handleException(
-						"InvalidInputPattern", "fields", "path",
-						className
+						exceptionType = "InvalidInputPattern",
+						fieldPath = listOf("fields", "path"),
+						className = className
 					)
 				}
 			}

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Filter.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Filter.kt
@@ -2,6 +2,7 @@ package io.mosip.openID4VP.authorizationRequest.presentationDefinition
 
 import Generated
 import io.mosip.openID4VP.common.Logger
+import isNeitherNullNorEmpty
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -57,10 +58,10 @@ object FilterSerializer : KSerializer<Filter> {
 class Filter(val type: String, val pattern: String) {
 	fun validate() {
 		try {
-			require(type.isNotEmpty()) {
+			require(isNeitherNullNorEmpty(type)) {
 				throw Logger.handleException("InvalidInput", "filter", "type", className)
 			}
-			require(pattern.isNotEmpty()) {
+			require(isNeitherNullNorEmpty(pattern)) {
 				throw Logger.handleException("InvalidInput", "filter", "pattern", className)
 			}
 		} catch (exception: Exception) {

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Filter.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Filter.kt
@@ -1,11 +1,10 @@
 package io.mosip.openID4VP.authorizationRequest.presentationDefinition
 
-import FieldDeserializer
 import Generated
+import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.common.Logger
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.descriptors.element

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Filter.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Filter.kt
@@ -36,10 +36,18 @@ object FilterSerializer : KSerializer<Filter> {
 		builtInDecoder.endStructure(descriptor)
 
 		requireNotNull(type) {
-			throw Logger.handleException("MissingInput", "filter", "type", className)
+			throw Logger.handleException(
+				exceptionType = "MissingInput",
+				fieldPath = listOf("filter", "type"),
+				className = className
+			)
 		}
 		requireNotNull(pattern) {
-			throw Logger.handleException("MissingInput", "filter", "pattern", className)
+			throw Logger.handleException(
+				exceptionType = "MissingInput",
+				fieldPath = listOf("filter", "pattern"),
+				className = className
+			)
 		}
 
 		return Filter(type = type, pattern = pattern)
@@ -59,10 +67,18 @@ class Filter(val type: String, val pattern: String) {
 	fun validate() {
 		try {
 			require(isNeitherNullNorEmpty(type)) {
-				throw Logger.handleException("InvalidInput", "filter", "type", className)
+				throw Logger.handleException(
+					exceptionType = "InvalidInput",
+					fieldPath = listOf("filter", "type"),
+					className = className
+				)
 			}
 			require(isNeitherNullNorEmpty(pattern)) {
-				throw Logger.handleException("InvalidInput", "filter", "pattern", className)
+				throw Logger.handleException(
+					exceptionType = "InvalidInput",
+					fieldPath = listOf("filter", "pattern"),
+					className = className
+				)
 			}
 		} catch (exception: Exception) {
 			throw exception

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptor.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptor.kt
@@ -4,6 +4,7 @@ import Generated
 import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.credentialFormatTypes.Format
+import isNeitherNullNorEmpty
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -84,7 +85,7 @@ class InputDescriptor(
 ) {
 	fun validate() {
 		try {
-			require(id.isNotEmpty()) {
+			require(isNeitherNullNorEmpty(id)) {
 				throw Logger.handleException("InvalidInput", "input_descriptor", "id", className)
 			}
 			format?.validate()

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptor.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptor.kt
@@ -48,10 +48,18 @@ object InputDescriptorSerializer : KSerializer<InputDescriptor> {
 		builtInDecoder.endStructure(descriptor)
 
 		requireNotNull(id) {
-			throw Logger.handleException("MissingInput", "input_descriptor", "id", className)
+			throw Logger.handleException(
+				exceptionType = "MissingInput",
+				fieldPath = listOf("input_descriptor", "id"),
+				className = className
+			)
 		}
 		requireNotNull(constraints) {
-			throw Logger.handleException("MissingInput", "input_descriptor", "constraints", className)
+			throw Logger.handleException(
+				exceptionType = "MissingInput",
+				fieldPath = listOf("input_descriptor", "constraints"),
+				className = className
+			)
 		}
 
 		return InputDescriptor(
@@ -86,7 +94,11 @@ class InputDescriptor(
 	fun validate() {
 		try {
 			require(isNeitherNullNorEmpty(id)) {
-				throw Logger.handleException("InvalidInput", "input_descriptor", "id", className)
+				throw Logger.handleException(
+					exceptionType = "InvalidInput",
+					fieldPath = listOf("input_descriptor", "id"),
+					className = className
+				)
 			}
 			format?.validate()
 			constraints.validate()

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptor.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptor.kt
@@ -1,13 +1,12 @@
 package io.mosip.openID4VP.authorizationRequest.presentationDefinition
 
-import FieldDeserializer
 import Generated
 import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
+import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.credentialFormatTypes.Format
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.descriptors.element

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinition.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinition.kt
@@ -5,6 +5,7 @@ import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExc
 import io.mosip.openID4VP.authorizationRequest.Validatable
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.credentialFormatTypes.Format
+import isNeitherNullNorEmpty
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -93,7 +94,7 @@ class PresentationDefinition(
 
 	override fun validate() {
 		try {
-			require(id.isNotEmpty()) {
+			require(isNeitherNullNorEmpty(id)) {
 				throw Logger.handleException("InvalidInput", "presentation_definition", "id", className)
 			}
 			require(inputDescriptors.isNotEmpty()) {

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinition.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinition.kt
@@ -55,10 +55,18 @@ object PresentationDefinitionSerializer : KSerializer<PresentationDefinition> {
 		builtInDecoder.endStructure(descriptor)
 
 		requireNotNull(id) {
-			throw Logger.handleException("MissingInput", "presentation_definition", "id", className)
+			throw Logger.handleException(
+				exceptionType = "MissingInput",
+				fieldPath = listOf("presentation_definition", "id"),
+				className = className
+			)
 		}
 		requireNotNull(inputDescriptors) {
-			throw Logger.handleException("MissingInput", "presentation_definition", "input_descriptors", className)
+			throw Logger.handleException(
+				exceptionType = "MissingInput",
+				fieldPath = listOf("presentation_definition", "input_descriptors"),
+				className = className
+			)
 		}
 
 		return PresentationDefinition(
@@ -95,10 +103,18 @@ class PresentationDefinition(
 	override fun validate() {
 		try {
 			require(isNeitherNullNorEmpty(id)) {
-				throw Logger.handleException("InvalidInput", "presentation_definition", "id", className)
+				throw Logger.handleException(
+					exceptionType = "InvalidInput",
+					fieldPath = listOf("presentation_definition", "id"),
+					className = className
+				)
 			}
 			require(inputDescriptors.isNotEmpty()) {
-				throw Logger.handleException("InvalidInput", "presentation_definition", "input_descriptors", className)
+				throw Logger.handleException(
+					exceptionType = "InvalidInput",
+					fieldPath = listOf("presentation_definition", "input_descriptors"),
+					className = className
+				)
 			}
 
 			inputDescriptors.forEach { inputDescriptor ->

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinition.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinition.kt
@@ -1,9 +1,9 @@
 package io.mosip.openID4VP.authorizationRequest.presentationDefinition
 
-import FieldDeserializer
 import Generated
 import io.mosip.openID4VP.authorizationRequest.Validatable
 import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
+import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.credentialFormatTypes.Format
 import kotlinx.serialization.KSerializer

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinition.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinition.kt
@@ -1,11 +1,11 @@
 package io.mosip.openID4VP.authorizationRequest.presentationDefinition
 
+import FieldDeserializer
 import Generated
-import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
 import io.mosip.openID4VP.authorizationRequest.Validatable
+import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.credentialFormatTypes.Format
-import isNeitherNullNorEmpty
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -13,9 +13,10 @@ import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.descriptors.element
-import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.jsonObject
 
 private val className = PresentationDefinition::class.simpleName!!
 
@@ -30,50 +31,39 @@ object PresentationDefinitionSerializer : KSerializer<PresentationDefinition> {
 		}
 
 	override fun deserialize(decoder: Decoder): PresentationDefinition {
-		val builtInDecoder = decoder.beginStructure(descriptor)
-		var id: String? = null
-		var inputDescriptors: List<InputDescriptor>? = null
-		var name: String? = null
-		var purpose: String? = null
-		var format: Format? = null
-
-		loop@ while (true) {
-			when (builtInDecoder.decodeElementIndex(descriptor)) {
-				CompositeDecoder.DECODE_DONE -> break@loop
-				0 -> id = builtInDecoder.decodeStringElement(descriptor, 0)
-				1 -> inputDescriptors = builtInDecoder.decodeSerializableElement(
-					descriptor, 1, ListSerializer(InputDescriptor.serializer())
-				)
-
-				2 -> name = builtInDecoder.decodeStringElement(descriptor, 2)
-				3 -> purpose = builtInDecoder.decodeStringElement(descriptor, 3)
-				4 -> format =
-					builtInDecoder.decodeSerializableElement(descriptor, 4, Format.serializer())
-			}
-		}
-
-		builtInDecoder.endStructure(descriptor)
-
-		requireNotNull(id) {
+		val jsonDecoder = try {
+			decoder as JsonDecoder
+		} catch (e: ClassCastException) {
 			throw Logger.handleException(
-				exceptionType = "MissingInput",
-				fieldPath = listOf("presentation_definition", "id"),
+				exceptionType = "DeserializationFailure",
+				fieldPath = listOf("presentation_definition"),
+				message = e.message!!,
 				className = className
 			)
 		}
-		requireNotNull(inputDescriptors) {
-			throw Logger.handleException(
-				exceptionType = "MissingInput",
-				fieldPath = listOf("presentation_definition", "input_descriptors"),
-				className = className
-			)
-		}
+		val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
+		val deserializer = FieldDeserializer(
+			jsonObject = jsonObject, className = className, parentField = "presentation_definition"
+		)
 
+		val id: String? =
+			deserializer.deserializeField(key = "id", fieldType = "String", isMandatory = true)
+		val inputDescriptors: List<InputDescriptor>? = deserializer.deserializeField(
+			key = "input_descriptors",
+			fieldType = "List<*>",
+			deserializer = ListSerializer(InputDescriptor.serializer()),
+			isMandatory = true
+		)
+		val name: String? = deserializer.deserializeField(key = "name", fieldType = "String")
+		val purpose: String? = deserializer.deserializeField(key = "purpose", fieldType = "String")
+		val format: Format? = deserializer.deserializeField(
+			key = "format", fieldType = "Format", deserializer = Format.serializer()
+		)
+		println("id::"+id)
+		println("desc::"+inputDescriptors)
 		return PresentationDefinition(
-			id = id,
-			inputDescriptors = inputDescriptors,
-			name = name,
-			purpose = purpose, format = format
+			id = id!!, inputDescriptors = inputDescriptors!!,
+			name = name, purpose = purpose, format = format
 		)
 	}
 
@@ -102,25 +92,9 @@ class PresentationDefinition(
 
 	override fun validate() {
 		try {
-			require(isNeitherNullNorEmpty(id)) {
-				throw Logger.handleException(
-					exceptionType = "InvalidInput",
-					fieldPath = listOf("presentation_definition", "id"),
-					className = className
-				)
-			}
-			require(inputDescriptors.isNotEmpty()) {
-				throw Logger.handleException(
-					exceptionType = "InvalidInput",
-					fieldPath = listOf("presentation_definition", "input_descriptors"),
-					className = className
-				)
-			}
-
 			inputDescriptors.forEach { inputDescriptor ->
 				inputDescriptor.validate()
 			}
-			format?.validate()
 		} catch (exception: AuthorizationRequestExceptions.InvalidInput) {
 			throw exception
 		}

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinition.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinition.kt
@@ -50,7 +50,7 @@ object PresentationDefinitionSerializer : KSerializer<PresentationDefinition> {
 			deserializer.deserializeField(key = "id", fieldType = "String", isMandatory = true)
 		val inputDescriptors: List<InputDescriptor>? = deserializer.deserializeField(
 			key = "input_descriptors",
-			fieldType = "List<*>",
+			fieldType = "List<InputDescriptor>",
 			deserializer = ListSerializer(InputDescriptor.serializer()),
 			isMandatory = true
 		)
@@ -59,8 +59,6 @@ object PresentationDefinitionSerializer : KSerializer<PresentationDefinition> {
 		val format: Format? = deserializer.deserializeField(
 			key = "format", fieldType = "Format", deserializer = Format.serializer()
 		)
-		println("id::"+id)
-		println("desc::"+inputDescriptors)
 		return PresentationDefinition(
 			id = id!!, inputDescriptors = inputDescriptors!!,
 			name = name, purpose = purpose, format = format

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponse.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponse.kt
@@ -1,6 +1,5 @@
 package io.mosip.openID4VP.authorizationResponse
 
-import io.mosip.openID4VP.authorizationResponse.exception.AuthorizationResponseExceptions
 import io.mosip.openID4VP.authorizationResponse.presentationSubmission.DescriptorMap
 import io.mosip.openID4VP.authorizationResponse.presentationSubmission.PresentationSubmission
 import io.mosip.openID4VP.authorizationResponse.presentationSubmission.VPToken
@@ -8,7 +7,8 @@ import io.mosip.openID4VP.authorizationResponse.presentationSubmission.VPTokenFo
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.common.UUIDGenerator
 import io.mosip.openID4VP.dto.VPResponseMetadata
-import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHttpPostRequest
+import io.mosip.openID4VP.networkManager.HTTP_METHOD
+import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -125,7 +125,12 @@ class AuthorizationResponse {
                     "state" to state
                 )
 
-                return sendHttpPostRequest(responseUri, bodyParams)
+                return sendHTTPRequest(
+                    url = responseUri,
+                    method = HTTP_METHOD.POST,
+                    bodyParams = bodyParams,
+                    headers = mapOf("Content-Type" to "application/x-www-form-urlencoded")
+                )
             } catch (exception: Exception) {
                 throw exception
             }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponse.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponse.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 private val logTag = Logger.getLogTag(AuthorizationResponse::class.simpleName!!)
+private val className = AuthorizationResponse::class.simpleName!!
 
 class AuthorizationResponse {
     companion object {
@@ -36,8 +37,12 @@ class AuthorizationResponse {
                 )
                 return Json.encodeToString(vpTokenForSigning)
             } catch (exception: SerializationException) {
-                Logger.error(logTag, exception)
-                throw AuthorizationResponseExceptions.JsonEncodingException("vpTokenForSigning")
+                throw Logger.handleException(
+                    exceptionType = "JsonEncodingFailed",
+                    message = exception.message,
+                    fieldPath = listOf("vp_token_for_signing"),
+                    className = className
+                )
             } catch (exception: Exception) {
                 Logger.error(logTag, exception)
                 throw exception
@@ -95,14 +100,22 @@ class AuthorizationResponse {
             try {
                 encodedVPToken = Json.encodeToString(vpToken)
             } catch (exception: Exception) {
-                Logger.error(logTag, exception)
-                throw AuthorizationResponseExceptions.JsonEncodingException("vpToken")
+                throw Logger.handleException(
+                    exceptionType = "JsonEncodingFailed",
+                    message = exception.message,
+                    fieldPath = listOf("vp_token"),
+                    className = className
+                )
             }
             try {
                 encodedPresentationSubmission = Json.encodeToString(presentationSubmission)
             } catch (exception: Exception) {
-                Logger.error(logTag, exception)
-                throw AuthorizationResponseExceptions.JsonEncodingException("presentationSubmission")
+                throw Logger.handleException(
+                    exceptionType = "JsonEncodingFailed",
+                    message = exception.message,
+                    fieldPath = listOf("presentation_submission"),
+                    className = className
+                )
             }
 
             try {

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/Decoder.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/Decoder.kt
@@ -4,12 +4,18 @@ import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExc
 import org.apache.commons.codec.binary.Base64
 import java.nio.charset.StandardCharsets
 
+private val className = Decoder::class.simpleName!!
 object Decoder {
     private val logTag = Logger.getLogTag(this::class.simpleName!!)
 
     fun decodeBase64ToString(encodedData: String): String {
         when {
-            encodedData.isEmpty() -> throw AuthorizationRequestExceptions.InvalidInput("encoded data")
+            encodedData.isEmpty() -> throw Logger.handleException(
+                exceptionType = "InvalidInput",
+                fieldPath = listOf("encoded data"),
+                className = className,
+                fieldType = encodedData::class.simpleName
+            )
             else -> {
                 try {
                     val decodedBytes: ByteArray = Base64.decodeBase64(encodedData)

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/FieldDeserializer.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/FieldDeserializer.kt
@@ -1,4 +1,5 @@
-import io.mosip.openID4VP.common.Logger
+package io.mosip.openID4VP.common
+
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/FieldDeserializer.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/FieldDeserializer.kt
@@ -1,0 +1,69 @@
+import io.mosip.openID4VP.common.Logger
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+
+class FieldDeserializer(
+	private val jsonObject: JsonObject,
+	private val className: String,
+	private val parentField: String
+) {
+	fun <T> deserializeField(
+		key: String,
+		fieldType: String,
+		deserializer: DeserializationStrategy<T>? = null,
+		isMandatory: Boolean = false,
+	): T? {
+		val data = jsonObject[key]
+
+		//field is mandatory but it is not present in the input
+		if (data == null && isMandatory) {
+			throw Logger.handleException(
+				exceptionType = "MissingInput",
+				fieldPath = listOf(parentField, key),
+				className = className
+			)
+		} else if (data == JsonNull) {
+			throw Logger.handleException(
+				exceptionType = "InvalidInput",
+				fieldPath = listOf(parentField, key),
+				className = className,
+				fieldType = fieldType
+			)
+		}
+		//field is mandatory or optional and it is present in the input
+		if (data != null) {
+			val res = when {
+				deserializer != null -> Json.decodeFromJsonElement(
+					deserializer,
+					data
+				) // Custom fields
+				fieldType == "String" -> (data as JsonPrimitive).content as T
+				fieldType == "Boolean" -> (data as JsonPrimitive).boolean as T
+				fieldType.startsWith("List") -> Json.decodeFromJsonElement(
+					ListSerializer(String.serializer()),
+					data
+				) as T
+
+				else -> throw SerializationException("Unsupported field type: $fieldType")
+			}
+			require(validateField(res, fieldType)) {
+				throw Logger.handleException(
+					exceptionType = "InvalidInput",
+					fieldPath = listOf(parentField, key),
+					className = className,
+					fieldType = fieldType
+				)
+			}
+			return res
+		} else {
+			return null
+		}
+	}
+}

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/Logger.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/Logger.kt
@@ -6,7 +6,7 @@ import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExc
 object Logger {
     private var traceabilityId: String? = null
 
-    fun setTraceability(traceabilityId: String) {
+    fun setTraceabilityId(traceabilityId: String) {
         this.traceabilityId = traceabilityId
     }
 
@@ -19,14 +19,41 @@ object Logger {
     }
 
     fun handleException(
-        exceptionType: String, parentField: String, currentField: String, className: String
+        exceptionType: String,
+        message: String? = null,
+        fieldPath: List<String>? = null,
+        className: String
     ): Exception {
-        val fieldPath = "$parentField : $currentField"
+        var fieldPathAsString: String = ""
+        fieldPath?.let {
+            fieldPathAsString = fieldPath.joinToString("->")
+        }
         var exception = Exception()
-        when(exceptionType){
-            "MissingInput" -> exception = AuthorizationRequestExceptions.MissingInput(fieldPath)
-            "InvalidInput" -> exception = AuthorizationRequestExceptions.InvalidInput(fieldPath)
-            "InvalidInputPattern" -> exception = AuthorizationRequestExceptions.InvalidInputPattern(fieldPath)
+        when (exceptionType) {
+            "MissingInput" -> exception =
+                AuthorizationRequestExceptions.MissingInput(fieldPath = fieldPathAsString)
+
+            "InvalidInput" -> exception =
+                AuthorizationRequestExceptions.InvalidInput(fieldPath = fieldPathAsString)
+
+            "InvalidInputPattern" -> exception =
+                AuthorizationRequestExceptions.InvalidInputPattern(fieldPath = fieldPathAsString)
+
+            "InvalidQueryParams" -> exception =
+                AuthorizationRequestExceptions.InvalidQueryParams(message = message ?: "")
+
+            "JsonEncodingFailed" -> exception = AuthorizationRequestExceptions.JsonEncodingFailed(
+                fieldPath = fieldPathAsString, message = message ?: ""
+            )
+
+            "InvalidVerifierClientID" -> exception =
+                AuthorizationRequestExceptions.InvalidVerifierClientID()
+
+            "InvalidLimitDisclosure" -> exception =
+                AuthorizationRequestExceptions.InvalidLimitDisclosure()
+
+            "" -> exception =
+                Exception("An unexpected exception occurred: exception type: $exceptionType")
         }
         this.error(getLogTag(className), exception)
         return exception

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/Logger.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/Logger.kt
@@ -22,7 +22,8 @@ object Logger {
         exceptionType: String,
         message: String? = null,
         fieldPath: List<String>? = null,
-        className: String
+        className: String,
+        fieldType: Any? = null
     ): Exception {
         var fieldPathAsString: String = ""
         fieldPath?.let {
@@ -34,7 +35,10 @@ object Logger {
                 AuthorizationRequestExceptions.MissingInput(fieldPath = fieldPathAsString)
 
             "InvalidInput" -> exception =
-                AuthorizationRequestExceptions.InvalidInput(fieldPath = fieldPathAsString)
+                AuthorizationRequestExceptions.InvalidInput(
+                    fieldPath = fieldPathAsString,
+                    fieldType = fieldType
+                )
 
             "InvalidInputPattern" -> exception =
                 AuthorizationRequestExceptions.InvalidInputPattern(fieldPath = fieldPathAsString)
@@ -52,6 +56,12 @@ object Logger {
             "InvalidLimitDisclosure" -> exception =
                 AuthorizationRequestExceptions.InvalidLimitDisclosure()
 
+            "DeserializationFailure" -> exception =
+                AuthorizationRequestExceptions.DeserializationFailure(
+                    fieldPath = fieldPathAsString,
+                    message = message ?: ""
+                )
+                
             "" -> exception =
                 Exception("An unexpected exception occurred: exception type: $exceptionType")
         }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/fieldValidator.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/fieldValidator.kt
@@ -1,3 +1,3 @@
-fun isNeitherNullNorEmpty(field: String): Boolean {
-	return field != "null" && field.isNotEmpty()
+fun isNeitherNullNorEmpty(field: String?): Boolean {
+	return field != "null" && !field.isNullOrEmpty()
 }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/fieldValidator.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/fieldValidator.kt
@@ -1,3 +1,5 @@
+package io.mosip.openID4VP.common
+
 fun validateField(field: Any?, fieldType: String?): Boolean {
 	var res = true
 	when {

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/fieldValidator.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/fieldValidator.kt
@@ -1,0 +1,3 @@
+fun isNeitherNullNorEmpty(field: String): Boolean {
+	return field != "null" && field.isNotEmpty()
+}

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/fieldValidator.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/fieldValidator.kt
@@ -1,14 +1,11 @@
-import kotlinx.serialization.json.JsonNull
-
 fun validateField(field: Any?, fieldType: String?): Boolean {
 	var res = true
 	when {
-		fieldType == "String" -> res = field.toString().isNotEmpty() && field != JsonNull
+		fieldType == "String" -> res = field.toString().isNotEmpty()
 
-		fieldType?.startsWith("List") == true -> res =
-			field != JsonNull && (field as? List<*>)?.isNotEmpty() ?: false
+		fieldType?.startsWith("List") == true -> res = (field as? List<*>)?.isNotEmpty() ?: false
 
-		fieldType == "Boolean" -> res = field != JsonNull && (field == true || field == false)
+		fieldType == "Boolean" -> res = (field == true || field == false)
 	}
 	return res
 }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/fieldValidator.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/fieldValidator.kt
@@ -1,3 +1,18 @@
-fun isNeitherNullNorEmpty(field: String?): Boolean {
-	return field != "null" && !field.isNullOrEmpty()
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+
+fun validateField(field: Any?, fieldType: String?): Boolean {
+	var res = true
+	when {
+		fieldType == "String" -> res =
+			field != "null" && field.toString().isNotEmpty() && field != JsonNull
+
+		fieldType?.startsWith("List") == true -> res =
+			field != JsonNull && (field as? List<*>)?.isNotEmpty() ?: false
+
+		fieldType == "Boolean" -> res = field != JsonNull && (field == true || field == false)
+		else -> res
+	}
+	println("validation result: " + res)
+	return res
 }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/fieldValidator.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/fieldValidator.kt
@@ -13,6 +13,5 @@ fun validateField(field: Any?, fieldType: String?): Boolean {
 		fieldType == "Boolean" -> res = field != JsonNull && (field == true || field == false)
 		else -> res
 	}
-	println("validation result: " + res)
 	return res
 }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/fieldValidator.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/fieldValidator.kt
@@ -1,17 +1,14 @@
 import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonPrimitive
 
 fun validateField(field: Any?, fieldType: String?): Boolean {
 	var res = true
 	when {
-		fieldType == "String" -> res =
-			field != "null" && field.toString().isNotEmpty() && field != JsonNull
+		fieldType == "String" -> res = field.toString().isNotEmpty() && field != JsonNull
 
 		fieldType?.startsWith("List") == true -> res =
 			field != JsonNull && (field as? List<*>)?.isNotEmpty() ?: false
 
 		fieldType == "Boolean" -> res = field != JsonNull && (field == true || field == false)
-		else -> res
 	}
 	return res
 }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/credentialFormatTypes/Format.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/credentialFormatTypes/Format.kt
@@ -1,7 +1,6 @@
 package io.mosip.openID4VP.credentialFormatTypes
 
 import Generated
-import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -51,13 +50,4 @@ object FormatSerializer : KSerializer<Format> {
 @Serializable(with = FormatSerializer::class)
 class Format(
 	@SerialName("ldp_vc") val ldpVc: LdpFormat?,
-) {
-	fun validate() {
-		try {
-			ldpVc?.validate()
-		} catch (e: AuthorizationRequestExceptions.InvalidInput) {
-			throw e
-		}
-	}
-
-}
+)

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/credentialFormatTypes/LdpFormat.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/credentialFormatTypes/LdpFormat.kt
@@ -40,7 +40,7 @@ object LdpFormatSerializer : KSerializer<LdpFormat> {
 
 		val proofType: List<String>? = deserializer.deserializeField(
 			key = "proof_type",
-			fieldType = "List<*>",
+			fieldType = "List<String>",
 			deserializer = ListSerializer(String.serializer()),
 			isMandatory = true
 		)

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/credentialFormatTypes/LdpFormat.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/credentialFormatTypes/LdpFormat.kt
@@ -1,7 +1,9 @@
 package io.mosip.openID4VP.credentialFormatTypes
 
 import Generated
+import io.mosip.openID4VP.authorizationRequest.ClientMetadata
 import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
+import io.mosip.openID4VP.common.Logger
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -15,6 +17,7 @@ import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+private val className = LdpFormat::class.simpleName!!
 object LdpFormatSerializer : KSerializer<LdpFormat> {
 	override val descriptor: SerialDescriptor = buildClassSerialDescriptor("LdpFormat") {
 		element<List<String>>("proof_type")
@@ -37,8 +40,13 @@ object LdpFormatSerializer : KSerializer<LdpFormat> {
 
 		builtInDecoder.endStructure(descriptor)
 
-		requireNotNull(proofType) { throw AuthorizationRequestExceptions.MissingInput("LdpFormat : proofType") }
-
+		requireNotNull(proofType) {
+			throw Logger.handleException(
+				exceptionType = "MissingInput",
+				fieldPath = listOf("ldpFormat", "proof_type"),
+				className = className
+			)
+		}
 		return LdpFormat(proofType = proofType)
 	}
 

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/credentialFormatTypes/LdpFormat.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/credentialFormatTypes/LdpFormat.kt
@@ -1,7 +1,7 @@
 package io.mosip.openID4VP.credentialFormatTypes
 
-import FieldDeserializer
 import Generated
+import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.common.Logger
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/dto/VPResponseMetadata.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/dto/VPResponseMetadata.kt
@@ -1,7 +1,7 @@
 package io.mosip.openID4VP.dto
 
 import io.mosip.openID4VP.common.Logger
-import validateField
+import io.mosip.openID4VP.common.validateField
 
 private val className = VPResponseMetadata::class.simpleName!!
 data class VPResponseMetadata(

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/dto/VPResponseMetadata.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/dto/VPResponseMetadata.kt
@@ -19,7 +19,7 @@ data class VPResponseMetadata(
         )
 
         requiredParams.forEach { (key, value) ->
-            require(validateField(value, value::class.simpleName)) {
+            require(value != "null" && validateField(value, "String")) {
                 throw Logger.handleException(
                     exceptionType = "InvalidInput",
                     fieldPath = listOf("vp response metadata",key),

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/dto/VPResponseMetadata.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/dto/VPResponseMetadata.kt
@@ -1,7 +1,7 @@
 package io.mosip.openID4VP.dto
 
 import io.mosip.openID4VP.common.Logger
-import isNeitherNullNorEmpty
+import validateField
 
 private val className = VPResponseMetadata::class.simpleName!!
 data class VPResponseMetadata(
@@ -19,11 +19,12 @@ data class VPResponseMetadata(
         )
 
         requiredParams.forEach { (key, value) ->
-            require(isNeitherNullNorEmpty(value)) {
+            require(validateField(value, value::class.simpleName)) {
                 throw Logger.handleException(
                     exceptionType = "InvalidInput",
                     fieldPath = listOf("vp response metadata",key),
-                    className = className
+                    className = className,
+                    fieldType = key::class.simpleName
                 )
             }
         }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/dto/VPResponseMetadata.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/dto/VPResponseMetadata.kt
@@ -1,6 +1,7 @@
 package io.mosip.openID4VP.dto
 
 import io.mosip.openID4VP.common.Logger
+import isNeitherNullNorEmpty
 
 private val className = VPResponseMetadata::class.simpleName!!
 data class VPResponseMetadata(
@@ -18,7 +19,7 @@ data class VPResponseMetadata(
         )
 
         requiredParams.forEach { (key, value) ->
-            if (value == "" || value == "null") {
+            require(isNeitherNullNorEmpty(value)) {
                 throw Logger.handleException(
                     exceptionType = "InvalidInput",
                     fieldPath = listOf("vp response metadata",key),

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/dto/VPResponseMetadata.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/dto/VPResponseMetadata.kt
@@ -1,7 +1,8 @@
 package io.mosip.openID4VP.dto
 
-import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
+import io.mosip.openID4VP.common.Logger
 
+private val className = VPResponseMetadata::class.simpleName!!
 data class VPResponseMetadata(
     val jws: String,
     val signatureAlgorithm: String,
@@ -18,7 +19,11 @@ data class VPResponseMetadata(
 
         requiredParams.forEach { (key, value) ->
             if (value == "" || value == "null") {
-                throw AuthorizationRequestExceptions.InvalidInput(key)
+                throw Logger.handleException(
+                    exceptionType = "InvalidInput",
+                    fieldPath = listOf("vp response metadata",key),
+                    className = className
+                )
             }
         }
     }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/networkManager/NetworkManagerClient.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/networkManager/NetworkManagerClient.kt
@@ -29,7 +29,7 @@ class NetworkManagerClient {
 				if (response.code == 200) {
 					return response.message
 				} else {
-					throw NetworkManagerClientExceptions.NetworkRequestFailed(response.toString())
+					throw Exception(response.toString())
 				}
 			} catch (exception: InterruptedIOException) {
 				val specificException =
@@ -37,8 +37,10 @@ class NetworkManagerClient {
 				Logger.error(logTag, specificException)
 				throw specificException
 			} catch (exception: Exception) {
-				Logger.error(logTag, exception)
-				throw exception
+				val specificException =
+					NetworkManagerClientExceptions.NetworkRequestFailed(exception.message!!)
+				Logger.error(logTag, specificException)
+				throw specificException
 			}
 		}
 

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/networkManager/NetworkManagerClient.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/networkManager/NetworkManagerClient.kt
@@ -41,5 +41,30 @@ class NetworkManagerClient {
 				throw exception
 			}
 		}
+
+		fun sendHttpGetRequest(
+			baseUrl: String
+		): String {
+			try {
+				val client = OkHttpClient.Builder().build()
+				val request =
+					Request.Builder().url(baseUrl).get().build()
+				val response: Response = client.newCall(request).execute()
+				if (response.isSuccessful) {
+					return response.body?.byteStream()?.bufferedReader().use { it?.readText() }
+						?: ""
+				} else {
+					throw NetworkManagerClientExceptions.NetworkRequestFailed(response.toString())
+				}
+			} catch (exception: InterruptedIOException) {
+				val specificException =
+					NetworkManagerClientExceptions.NetworkRequestTimeout()
+				Logger.error(logTag, specificException)
+				throw specificException
+			} catch (exception: Exception) {
+				Logger.error(logTag, exception)
+				throw exception
+			}
+		}
 	}
 }

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
@@ -252,7 +252,7 @@ fun createEncodedAuthorizationRequest(
     val clientMetadata: String? = if (params.containsKey("client_metadata")) {
         params["client_metadata"]
     } else {
-        """{"name":"verifier"}"""
+        """{"client_name":"verifier"}"""
     }
 
     authorizationRequestUrl.append("response_type=vp_token&response_mode=direct_post&nonce=$nonce&state=$state&response_uri=$responseUri&client_metadata=$clientMetadata")

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
@@ -7,6 +7,8 @@ import io.mockk.mockkStatic
 import io.mosip.openID4VP.OpenID4VP
 import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
 import io.mosip.openID4VP.dto.Verifier
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.apache.commons.codec.binary.Base64
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -20,6 +22,7 @@ class AuthorizationRequestTest {
     private lateinit var openID4VP: OpenID4VP
     private lateinit var trustedVerifiers: List<Verifier>
     private lateinit var presentationDefinition: String
+    private lateinit var presentationDefinitionUri: String
     private lateinit var encodedAuthorizationRequestUrl: String
     private lateinit var actualException: Exception
     private lateinit var expectedExceptionMessage: String
@@ -29,18 +32,17 @@ class AuthorizationRequestTest {
         openID4VP = OpenID4VP("test-OpenID4VP")
         trustedVerifiers = listOf(
             Verifier(
-                "https://verify.env1.net", listOf(
-                    "https://verify.env1.net/responseUri",
-                    "https://verify.env2.net/responseUri"
+                "https://verifier.env1.net", listOf(
+                    "https://verifier.env1.net/responseUri", "https://verifier.env2.net/responseUri"
                 )
             ), Verifier(
-                "https://verify.env2.net", listOf(
-                    "https://verify.env3.net/responseUri",
-                    "https://verify.env2.net/responseUri"
+                "https://verifier.env2.net", listOf(
+                    "https://verifier.env3.net/responseUri", "https://verifier.env2.net/responseUri"
                 )
             )
         )
         presentationDefinition = """{"id":"649d581c-f891-4969-9cd5-2c27385a348f","input_descriptors":[{"id":"idcardcredential","format":{"ldp_vc":{"proof_type":["Ed25519Signature2018"]}},"constraints":{"fields":[{"path":["$.type"]}]}}]}"""
+        presentationDefinitionUri = "verifier/presentation_definition_uri"
         mockkStatic(android.util.Log::class)
         every { Log.e(any(), any()) } answers {
             val tag = arg<String>(0)
@@ -78,13 +80,14 @@ class AuthorizationRequestTest {
     }
 
     @Test
-    fun `should throw exception if presentation_definition param is not present in Authorization Request`() {
+    fun `should throw exception if neither presentation_definition nor presentation_definition_uri param present in Authorization Request`() {
         encodedAuthorizationRequestUrl =
-            createEncodedAuthorizationRequest(clientId = "https://injiverify.dev2.mosip.net")
+            createEncodedAuthorizationRequest(clientId = "https://verifier.env1.net")
         val expectedExceptionMessage =
-            "Missing Input: presentation_definition param is required"
+            "Either presentation_definition or presentation_definition_uri request param must be present"
 
-        actualException = assertThrows(AuthorizationRequestExceptions.MissingInput::class.java) {
+        actualException =
+            assertThrows(AuthorizationRequestExceptions.InvalidQueryParams::class.java) {
             openID4VP.authenticateVerifier(
                 encodedAuthorizationRequestUrl, trustedVerifiers
             )
@@ -94,9 +97,26 @@ class AuthorizationRequestTest {
     }
 
     @Test
+    fun `should throw exception if both presentation_definition and presentation_definition_uri request params are present in Authorization Request`() {
+        encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
+            presentationDefinition = presentationDefinition,
+            presentationDefinitionUri = presentationDefinitionUri
+        )
+        val expectedExceptionMessage =
+            "Either presentation_definition or presentation_definition_uri request param can be provided but not both"
+        actualException =
+            assertThrows(AuthorizationRequestExceptions.InvalidQueryParams::class.java) {
+                openID4VP.authenticateVerifier(
+                    encodedAuthorizationRequestUrl, trustedVerifiers
+                )
+            }
+        assertEquals(expectedExceptionMessage, actualException.message)
+    }
+
+    @Test
     fun `should throw exception if received client_id is not matching with predefined Verifiers list client_id`() {
         encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
-            clientId = "https://verify.env4.net",
+            clientId = "https://verifier.env4.net",
             presentationDefinition = presentationDefinition
         )
         val expectedExceptionMessage =
@@ -117,7 +137,7 @@ class AuthorizationRequestTest {
         presentationDefinition =
             """{"id":"649d581c-f891-4969-9cd5-2c27385a348f","input_descriptors":[{"id":"idcardcredential","constraints":{"fields":[{"path":["$.type"]}], "limit_disclosure": "not preferred"}}]}"""
         encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
-            clientId = "https://verify.env1.net",
+            clientId = "https://verifier.env1.net",
             presentationDefinition = presentationDefinition
         )
         val expectedExceptionMessage =
@@ -134,9 +154,9 @@ class AuthorizationRequestTest {
     }
 
     @Test
-    fun `should return Authorization Request as Authentication Response if all the fields are present and valid in Authorization Request`() {
+    fun `should return Authorization Request as Authentication Response if presentation_definition & all the other fields are present and valid in Authorization Request`() {
         encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
-            clientId = "https://verify.env1.net",
+            clientId = "https://verifier.env1.net",
             presentationDefinition = presentationDefinition
         )
 
@@ -144,12 +164,30 @@ class AuthorizationRequestTest {
             openID4VP.authenticateVerifier(encodedAuthorizationRequestUrl, trustedVerifiers)
         assertTrue(actualValue is AuthorizationRequest)
     }
+
+    @Test
+    fun `should return Authorization Request as Authentication Response if presentation_definition_uri & all the other fields are present and valid in Authorization Request`() {
+        val mockWebServer = MockWebServer()
+        mockWebServer.start(8080)
+        val mockResponse = MockResponse().setResponseCode(200).setBody(presentationDefinition)
+        mockWebServer.enqueue(mockResponse)
+        encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
+            clientId = "https://verifier.env1.net",
+            presentationDefinitionUri = mockWebServer.url(presentationDefinitionUri).toString()
+        )
+
+        val actualValue =
+            openID4VP.authenticateVerifier(encodedAuthorizationRequestUrl, trustedVerifiers)
+        assertTrue(actualValue is AuthorizationRequest)
+        mockWebServer.shutdown()
+    }
 }
 
 fun createEncodedAuthorizationRequest(
     clientId: String? = null,
     presentationDefinition: String? = null,
-    responseUri: String = "https://verify.env2.net/responseUri"
+    presentationDefinitionUri: String? = null,
+    responseUri: String = "https://verifier.env2.net/responseUri"
 ): String {
     val state = "fsnC8ixCs6mWyV+00k23Qg=="
     val nonce = "bMHvX1HGhbh8zqlSWf/fuQ=="
@@ -158,6 +196,7 @@ fun createEncodedAuthorizationRequest(
 
     if (clientId != null) authorizationRequestUrl.append("client_id=$clientId&")
     if (presentationDefinition != null) authorizationRequestUrl.append("presentation_definition=$presentationDefinition&")
+    if (presentationDefinitionUri != null) authorizationRequestUrl.append("presentation_definition_uri=$presentationDefinitionUri&")
     authorizationRequestUrl.append("response_type=vp_token&response_mode=direct_post&nonce=$nonce&state=$state&response_uri=$responseUri&client_metadata=$clientMetadata")
     val encodedAuthorizationRequestInBytes = Base64.encodeBase64(
         authorizationRequestUrl.toString().toByteArray(

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
@@ -187,12 +187,12 @@ fun createEncodedAuthorizationRequest(
     clientId: String? = null,
     presentationDefinition: String? = null,
     presentationDefinitionUri: String? = null,
-    responseUri: String = "https://verifier.env2.net/responseUri"
+    responseUri: String = "https://verifier.env2.net/responseUri",
+    clientMetadata: String = """{"name":"verifier"}"""
 ): String {
     val state = "fsnC8ixCs6mWyV+00k23Qg=="
     val nonce = "bMHvX1HGhbh8zqlSWf/fuQ=="
     val authorizationRequestUrl = StringBuilder("")
-    val clientMetadata = """{"name":"verifier"}"""
 
     if (clientId != null) authorizationRequestUrl.append("client_id=$clientId&")
     if (presentationDefinition != null) authorizationRequestUrl.append("presentation_definition=$presentationDefinition&")

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
@@ -141,7 +141,7 @@ class AuthorizationRequestTest {
             presentationDefinition = presentationDefinition
         )
         val expectedExceptionMessage =
-            "Invalid Input: limit_disclosure value should be either required or preferred"
+            "Invalid Input: constraints->limit_disclosure value should be either required or preferred"
 
         actualException =
             assertThrows(AuthorizationRequestExceptions.InvalidLimitDisclosure::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/ClientMetadataTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/ClientMetadataTest.kt
@@ -53,9 +53,11 @@ class ClientMetadataTest {
 	@Test
 	fun `should throw missing input exception if client_metadata is available in request but doesn't contain name field`() {
 		encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
-			clientId = "https://verifier.env1.net",
-			presentationDefinition,
-			clientMetadata = """{}"""
+			mapOf(
+				"client_id" to "https://verifier.env1.net",
+				"presentation_definition" to presentationDefinition,
+				"client_metadata" to """{}"""
+			)
 		)
 		expectedExceptionMessage =
 			"Missing Input: client_metadata->name param is required"
@@ -74,9 +76,11 @@ class ClientMetadataTest {
 	@Test
 	fun `should throw invalid input exception if name field is available in client_metadata but the value is empty`() {
 		encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
-			clientId = "https://verifier.env1.net",
-			presentationDefinition,
-			clientMetadata = """{"name":""}"""
+			mapOf(
+				"client_id" to "https://verifier.env1.net",
+				"presentation_definition" to presentationDefinition,
+				"client_metadata" to """{"name":""}"""
+			)
 		)
 		val expectedExceptionMessage =
 			"Invalid Input: client_metadata->name value cannot be empty string or null"
@@ -94,9 +98,11 @@ class ClientMetadataTest {
 	@Test
 	fun `should throw invalid input exception if name field is available in client_metadata but the value is null`() {
 		encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
-			clientId = "https://verifier.env1.net",
-			presentationDefinition,
-			clientMetadata = """{"name":null}"""
+			mapOf(
+				"client_id" to "https://verifier.env1.net",
+				"presentation_definition" to presentationDefinition,
+				"client_metadata" to """{"name":null}"""
+			)
 		)
 		val expectedExceptionMessage =
 			"Invalid Input: client_metadata->name value cannot be empty string or null"
@@ -114,9 +120,11 @@ class ClientMetadataTest {
 	@Test
 	fun `should throw invalid input exception if log_url field is available in client_metadata but the value is empty`() {
 		encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
-			clientId = "https://verifier.env1.net",
-			presentationDefinition,
-			clientMetadata = """{"name":"verifier","logo_url":""}"""
+			mapOf(
+				"client_id" to "https://verifier.env1.net",
+				"presentation_definition" to presentationDefinition,
+				"client_metadata" to """{"name":"verifier","logo_url":""}"""
+			)
 		)
 		val expectedExceptionMessage =
 			"Invalid Input: client_metadata->logo_url value cannot be empty string or null"

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/ClientMetadataTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/ClientMetadataTest.kt
@@ -1,0 +1,113 @@
+package io.mosip.openID4VP.authorizationRequest
+
+import android.util.Log
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mosip.openID4VP.OpenID4VP
+import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
+import io.mosip.openID4VP.dto.Verifier
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class ClientMetadataTest {
+	private lateinit var presentationDefinition: String
+	private lateinit var expectedExceptionMessage: String
+	private lateinit var actualException: Exception
+	private lateinit var openID4VP: OpenID4VP
+	private lateinit var trustedVerifiers: List<Verifier>
+	private lateinit var encodedAuthorizationRequestUrl: String
+
+	@Before
+	fun setUp() {
+		mockkStatic(Log::class)
+		every { Log.e(any(), any()) } answers {
+			val tag = arg<String>(0)
+			val msg = arg<String>(1)
+			println("Error: logTag: $tag | Message: $msg")
+			0
+		}
+		openID4VP = OpenID4VP("test-OpenID4VP")
+		presentationDefinition =
+			"""{"id":"649d581c-f891-4969-9cd5-2c27385a348f","input_descriptors":[{"id":"idcardcredential","format":{"ldp_vc":{"proof_type":["Ed25519Signature2018"]}},"constraints":{"fields":[{"path":["$.type"]}]}}]}"""
+		trustedVerifiers = listOf(
+			Verifier(
+				"https://verifier.env1.net", listOf(
+					"https://verifier.env1.net/responseUri", "https://verifier.env2.net/responseUri"
+				)
+			), Verifier(
+				"https://verifier.env2.net", listOf(
+					"https://verifier.env3.net/responseUri", "https://verifier.env2.net/responseUri"
+				)
+			)
+		)
+	}
+
+	@After
+	fun tearDown() {
+		clearAllMocks()
+	}
+
+	@Test
+	fun `should throw missing input exception if client_metadata is available in request but doesn't contain name field`() {
+		encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
+			clientId = "https://verifier.env1.net",
+			presentationDefinition,
+			clientMetadata = """{}"""
+		)
+		expectedExceptionMessage =
+			"Missing Input: client_metadata : name param is required"
+
+		actualException =
+			Assert.assertThrows(AuthorizationRequestExceptions.MissingInput::class.java) {
+				openID4VP.authenticateVerifier(
+					encodedAuthorizationRequestUrl, trustedVerifiers
+				)
+			}
+
+
+		Assert.assertEquals(expectedExceptionMessage, actualException.message)
+	}
+
+	@Test
+	fun `should throw invalid input exception if name field is available in client_metadata but the value is empty`() {
+		encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
+			clientId = "https://verifier.env1.net",
+			presentationDefinition,
+			clientMetadata = """{"name":""}"""
+		)
+		val expectedExceptionMessage =
+			"Invalid Input: client_metadata : name value cannot be empty or null"
+
+		actualException =
+			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
+				openID4VP.authenticateVerifier(
+					encodedAuthorizationRequestUrl, trustedVerifiers
+				)
+			}
+
+		Assert.assertEquals(expectedExceptionMessage, actualException.message)
+	}
+
+	@Test
+	fun `should throw invalid input exception if log_url field is available in client_metadata but the value is empty`() {
+		encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
+			clientId = "https://verifier.env1.net",
+			presentationDefinition,
+			clientMetadata = """{"name":"verifier","logo_url":""}"""
+		)
+		val expectedExceptionMessage =
+			"Invalid Input: client_metadata : logo_url value cannot be empty or null"
+
+		actualException =
+			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
+				openID4VP.authenticateVerifier(
+					encodedAuthorizationRequestUrl, trustedVerifiers
+				)
+			}
+
+		Assert.assertEquals(expectedExceptionMessage, actualException.message)
+	}
+}

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/ClientMetadataTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/ClientMetadataTest.kt
@@ -79,7 +79,7 @@ class ClientMetadataTest {
 			clientMetadata = """{"name":""}"""
 		)
 		val expectedExceptionMessage =
-			"Invalid Input: client_metadata->name value cannot be empty or null"
+			"Invalid Input: client_metadata->name value cannot be empty string, null or null string"
 
 		actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
@@ -99,7 +99,7 @@ class ClientMetadataTest {
 			clientMetadata = """{"name":"verifier","logo_url":""}"""
 		)
 		val expectedExceptionMessage =
-			"Invalid Input: client_metadata->logo_url value cannot be empty or null"
+			"Invalid Input: client_metadata->logo_url value cannot be empty string, null or null string"
 
 		actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/ClientMetadataTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/ClientMetadataTest.kt
@@ -92,6 +92,26 @@ class ClientMetadataTest {
 	}
 
 	@Test
+	fun `should throw invalid input exception if name field is available in client_metadata but the value is null`() {
+		encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
+			clientId = "https://verifier.env1.net",
+			presentationDefinition,
+			clientMetadata = """{"name":null}"""
+		)
+		val expectedExceptionMessage =
+			"Invalid Input: client_metadata->name value cannot be empty string, null or null string"
+
+		actualException =
+			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
+				openID4VP.authenticateVerifier(
+					encodedAuthorizationRequestUrl, trustedVerifiers
+				)
+			}
+
+		Assert.assertEquals(expectedExceptionMessage, actualException.message)
+	}
+
+	@Test
 	fun `should throw invalid input exception if log_url field is available in client_metadata but the value is empty`() {
 		encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
 			clientId = "https://verifier.env1.net",

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/ClientMetadataTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/ClientMetadataTest.kt
@@ -79,7 +79,7 @@ class ClientMetadataTest {
 			clientMetadata = """{"name":""}"""
 		)
 		val expectedExceptionMessage =
-			"Invalid Input: client_metadata->name value cannot be empty string, null or null string"
+			"Invalid Input: client_metadata->name value cannot be empty string or null"
 
 		actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
@@ -99,7 +99,7 @@ class ClientMetadataTest {
 			clientMetadata = """{"name":null}"""
 		)
 		val expectedExceptionMessage =
-			"Invalid Input: client_metadata->name value cannot be empty string, null or null string"
+			"Invalid Input: client_metadata->name value cannot be empty string or null"
 
 		actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
@@ -119,7 +119,7 @@ class ClientMetadataTest {
 			clientMetadata = """{"name":"verifier","logo_url":""}"""
 		)
 		val expectedExceptionMessage =
-			"Invalid Input: client_metadata->logo_url value cannot be empty string, null or null string"
+			"Invalid Input: client_metadata->logo_url value cannot be empty string or null"
 
 		actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/ClientMetadataTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/ClientMetadataTest.kt
@@ -51,39 +51,16 @@ class ClientMetadataTest {
 	}
 
 	@Test
-	fun `should throw missing input exception if client_metadata is available in request but doesn't contain name field`() {
-		encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
-			mapOf(
-				"client_id" to "https://verifier.env1.net",
-				"presentation_definition" to presentationDefinition,
-				"client_metadata" to """{}"""
-			)
-		)
-		expectedExceptionMessage =
-			"Missing Input: client_metadata->name param is required"
-
-		actualException =
-			Assert.assertThrows(AuthorizationRequestExceptions.MissingInput::class.java) {
-				openID4VP.authenticateVerifier(
-					encodedAuthorizationRequestUrl, trustedVerifiers
-				)
-			}
-
-
-		Assert.assertEquals(expectedExceptionMessage, actualException.message)
-	}
-
-	@Test
 	fun `should throw invalid input exception if name field is available in client_metadata but the value is empty`() {
 		encodedAuthorizationRequestUrl = createEncodedAuthorizationRequest(
 			mapOf(
 				"client_id" to "https://verifier.env1.net",
 				"presentation_definition" to presentationDefinition,
-				"client_metadata" to """{"name":""}"""
+				"client_metadata" to """{"client_name":""}"""
 			)
 		)
 		val expectedExceptionMessage =
-			"Invalid Input: client_metadata->name value cannot be empty string or null"
+			"Invalid Input: client_metadata->client_name value cannot be empty string or null"
 
 		actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
@@ -101,11 +78,11 @@ class ClientMetadataTest {
 			mapOf(
 				"client_id" to "https://verifier.env1.net",
 				"presentation_definition" to presentationDefinition,
-				"client_metadata" to """{"name":null}"""
+				"client_metadata" to """{"client_name":null}"""
 			)
 		)
 		val expectedExceptionMessage =
-			"Invalid Input: client_metadata->name value cannot be empty string or null"
+			"Invalid Input: client_metadata->client_name value cannot be empty string or null"
 
 		actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
@@ -123,11 +100,11 @@ class ClientMetadataTest {
 			mapOf(
 				"client_id" to "https://verifier.env1.net",
 				"presentation_definition" to presentationDefinition,
-				"client_metadata" to """{"name":"verifier","logo_url":""}"""
+				"client_metadata" to """{"client_name":"verifier","logo_uri":""}"""
 			)
 		)
 		val expectedExceptionMessage =
-			"Invalid Input: client_metadata->logo_url value cannot be empty string or null"
+			"Invalid Input: client_metadata->logo_uri value cannot be empty string or null"
 
 		actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/ClientMetadataTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/ClientMetadataTest.kt
@@ -58,7 +58,7 @@ class ClientMetadataTest {
 			clientMetadata = """{}"""
 		)
 		expectedExceptionMessage =
-			"Missing Input: client_metadata : name param is required"
+			"Missing Input: client_metadata->name param is required"
 
 		actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.MissingInput::class.java) {
@@ -79,7 +79,7 @@ class ClientMetadataTest {
 			clientMetadata = """{"name":""}"""
 		)
 		val expectedExceptionMessage =
-			"Invalid Input: client_metadata : name value cannot be empty or null"
+			"Invalid Input: client_metadata->name value cannot be empty or null"
 
 		actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
@@ -99,7 +99,7 @@ class ClientMetadataTest {
 			clientMetadata = """{"name":"verifier","logo_url":""}"""
 		)
 		val expectedExceptionMessage =
-			"Invalid Input: client_metadata : logo_url value cannot be empty or null"
+			"Invalid Input: client_metadata->logo_url value cannot be empty or null"
 
 		actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/ConstraintsTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/ConstraintsTest.kt
@@ -35,7 +35,7 @@ class ConstraintsTest {
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","format":{"ldp_vc":{"proof_type":["RsaSignature2018"]}},"constraints":{"fields":[{"path":["$.type"]}],"limit_disclosure": "not preferred"}}]}"""
 
 		val expectedExceptionMessage =
-			"Invalid Input: limit_disclosure value should be either required or preferred"
+			"Invalid Input: constraints->limit_disclosure value should be either required or preferred"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidLimitDisclosure::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FieldsTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FieldsTest.kt
@@ -73,4 +73,18 @@ class FieldsTest {
 
 		Assert.assertEquals(expectedExceptionMessage, actualException.message)
 	}
+
+	@Test
+	fun `should throw invalid input exception if path param is present but it's value is null`() {
+		presentationDefinition =
+			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":null}]}}]}"""
+		expectedExceptionMessage = "Invalid Input: fields->path value cannot be empty or null"
+
+		val actualException =
+			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
+				deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
+			}
+
+		Assert.assertEquals(expectedExceptionMessage, actualException.message)
+	}
 }

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FieldsTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FieldsTest.kt
@@ -36,7 +36,7 @@ class FieldsTest {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$-type"]}]}}]}"""
 		expectedExceptionMessage =
-			"Invalid Input Pattern: fields : path pattern is not matching with OpenId4VP specification"
+			"Invalid Input Pattern: fields->path pattern is not matching with OpenId4VP specification"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInputPattern::class.java) {
@@ -50,7 +50,7 @@ class FieldsTest {
 	fun `should throw missing input exception if path param is missing`() {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{}]}}]}"""
-		expectedExceptionMessage = "Missing Input: fields : path param is required"
+		expectedExceptionMessage = "Missing Input: fields->path param is required"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.MissingInput::class.java) {
@@ -64,7 +64,7 @@ class FieldsTest {
 	fun `should throw invalid input exception if path param is empty`() {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":[]}]}}]}"""
-		expectedExceptionMessage = "Invalid Input: fields : path value cannot be empty or null"
+		expectedExceptionMessage = "Invalid Input: fields->path value cannot be empty or null"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FieldsTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FieldsTest.kt
@@ -64,7 +64,7 @@ class FieldsTest {
 	fun `should throw invalid input exception if path param is empty`() {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":[]}]}}]}"""
-		expectedExceptionMessage = "Invalid Input: fields->path value cannot be empty or null"
+		expectedExceptionMessage = "Invalid Input: fields->path value cannot be empty string, null or null string"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FieldsTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FieldsTest.kt
@@ -64,7 +64,7 @@ class FieldsTest {
 	fun `should throw invalid input exception if path param is empty`() {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":[]}]}}]}"""
-		expectedExceptionMessage = "Invalid Input: fields->path value cannot be empty string, null or null string"
+		expectedExceptionMessage = "Invalid Input: fields->path value cannot be empty or null"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FilterTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FilterTest.kt
@@ -63,7 +63,7 @@ class FilterTest {
 	fun `should throw invalid input pattern exception if type param is empty`() {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"], "filter":{"type":"","pattern":"MosipCredential"}}]}}]}"""
-		expectedExceptionMessage = "Invalid Input: filter->type value cannot be empty string, null or null string"
+		expectedExceptionMessage = "Invalid Input: filter->type value cannot be empty string or null"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
@@ -77,7 +77,7 @@ class FilterTest {
 	fun `should throw invalid input exception if pattern param is empty`() {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"], "filter":{"type":"string","pattern":""}}]}}]}"""
-		expectedExceptionMessage = "Invalid Input: filter->pattern value cannot be empty string, null or null string"
+		expectedExceptionMessage = "Invalid Input: filter->pattern value cannot be empty string or null"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
@@ -91,7 +91,7 @@ class FilterTest {
 	fun `should throw invalid input exception if pattern param is present but it's value is null`() {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"], "filter":{"type":"string","pattern":null}}]}}]}"""
-		expectedExceptionMessage = "Invalid Input: filter->pattern value cannot be empty string, null or null string"
+		expectedExceptionMessage = "Invalid Input: filter->pattern value cannot be empty string or null"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FilterTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FilterTest.kt
@@ -4,8 +4,8 @@ import android.util.Log
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockkStatic
-import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
 import io.mosip.openID4VP.authorizationRequest.deserializeAndValidate
+import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -35,7 +35,7 @@ class FilterTest {
 	fun `should throw missing input pattern exception if type param is missing`() {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"], "filter":{}}]}}]}"""
-		expectedExceptionMessage = "Missing Input: filter : type param is required"
+		expectedExceptionMessage = "Missing Input: filter->type param is required"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.MissingInput::class.java) {
@@ -49,7 +49,7 @@ class FilterTest {
 	fun `should throw missing input exception if pattern param is missing`() {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"], "filter":{"type":"string"}}]}}]}"""
-		expectedExceptionMessage = "Missing Input: filter : pattern param is required"
+		expectedExceptionMessage = "Missing Input: filter->pattern param is required"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.MissingInput::class.java) {
@@ -63,7 +63,7 @@ class FilterTest {
 	fun `should throw invalid input pattern exception if type param is empty`() {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"], "filter":{"type":"","pattern":"MosipCredential"}}]}}]}"""
-		expectedExceptionMessage = "Invalid Input: filter : type value cannot be empty or null"
+		expectedExceptionMessage = "Invalid Input: filter->type value cannot be empty or null"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
@@ -77,7 +77,7 @@ class FilterTest {
 	fun `should throw missing input exception if pattern param is empty`() {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"], "filter":{"type":"string","pattern":""}}]}}]}"""
-		expectedExceptionMessage = "Invalid Input: filter : pattern value cannot be empty or null"
+		expectedExceptionMessage = "Invalid Input: filter->pattern value cannot be empty or null"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FilterTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FilterTest.kt
@@ -63,7 +63,7 @@ class FilterTest {
 	fun `should throw invalid input pattern exception if type param is empty`() {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"], "filter":{"type":"","pattern":"MosipCredential"}}]}}]}"""
-		expectedExceptionMessage = "Invalid Input: filter->type value cannot be empty or null"
+		expectedExceptionMessage = "Invalid Input: filter->type value cannot be empty string, null or null string"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
@@ -77,7 +77,7 @@ class FilterTest {
 	fun `should throw missing input exception if pattern param is empty`() {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"], "filter":{"type":"string","pattern":""}}]}}]}"""
-		expectedExceptionMessage = "Invalid Input: filter->pattern value cannot be empty or null"
+		expectedExceptionMessage = "Invalid Input: filter->pattern value cannot be empty string, null or null string"
 
 		val actualException =
 			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FilterTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FilterTest.kt
@@ -74,9 +74,23 @@ class FilterTest {
 	}
 
 	@Test
-	fun `should throw missing input exception if pattern param is empty`() {
+	fun `should throw invalid input exception if pattern param is empty`() {
 		presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"], "filter":{"type":"string","pattern":""}}]}}]}"""
+		expectedExceptionMessage = "Invalid Input: filter->pattern value cannot be empty string, null or null string"
+
+		val actualException =
+			Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
+				deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
+			}
+
+		Assert.assertEquals(expectedExceptionMessage, actualException.message)
+	}
+
+	@Test
+	fun `should throw invalid input exception if pattern param is present but it's value is null`() {
+		presentationDefinition =
+			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"], "filter":{"type":"string","pattern":null}}]}}]}"""
 		expectedExceptionMessage = "Invalid Input: filter->pattern value cannot be empty string, null or null string"
 
 		val actualException =

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptorTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptorTest.kt
@@ -48,7 +48,7 @@ class InputDescriptorTest {
     @Test
     fun `should throw missing input exception if constraints param is missing`(){
         presentationDefinition =
-            """{"input_descriptors":[{"id":"id_123"}]}"""
+            """{"id":"pd_123","input_descriptors":[{"id":"id_123"}]}"""
         expectedExceptionMessage = "Missing Input: input_descriptor->constraints param is required"
 
         val actualException =

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptorTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptorTest.kt
@@ -63,7 +63,7 @@ class InputDescriptorTest {
     fun `should throw invalid input exception if id param value is empty`(){
         presentationDefinition =
             """{"id":"pd_123","input_descriptors":[{"id":"","constraints":{"fields":[{"path":["$.type"]}]}}]}"""
-        expectedExceptionMessage = "Invalid Input: input_descriptor->id value cannot be empty string, null or null string"
+        expectedExceptionMessage = "Invalid Input: input_descriptor->id value cannot be empty string or null"
 
         val actualException =
             Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
@@ -77,7 +77,7 @@ class InputDescriptorTest {
     fun `should throw invalid input exception if id param value is present but it's value is null`(){
         presentationDefinition =
             """{"id":"pd_123","input_descriptors":[{"id":null,"constraints":{"fields":[{"path":["$.type"]}]}}]}"""
-        expectedExceptionMessage = "Invalid Input: input_descriptor->id value cannot be empty string, null or null string"
+        expectedExceptionMessage = "Invalid Input: input_descriptor->id value cannot be empty string or null"
 
         val actualException =
             Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptorTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptorTest.kt
@@ -4,8 +4,8 @@ import android.util.Log
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockkStatic
-import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
 import io.mosip.openID4VP.authorizationRequest.deserializeAndValidate
+import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -35,7 +35,7 @@ class InputDescriptorTest {
     fun `should throw missing input exception if id param is missing`(){
         presentationDefinition =
             """{"id":"id_123","input_descriptors":[{"constraints":{"fields":[{"path":["$.type"]}]}}]}"""
-        expectedExceptionMessage = "Missing Input: input_descriptor : id param is required"
+        expectedExceptionMessage = "Missing Input: input_descriptor->id param is required"
 
         val actualException =
             Assert.assertThrows(AuthorizationRequestExceptions.MissingInput::class.java) {
@@ -49,7 +49,7 @@ class InputDescriptorTest {
     fun `should throw missing input exception if constraints param is missing`(){
         presentationDefinition =
             """{"input_descriptors":[{"id":"id_123"}]}"""
-        expectedExceptionMessage = "Missing Input: input_descriptor : constraints param is required"
+        expectedExceptionMessage = "Missing Input: input_descriptor->constraints param is required"
 
         val actualException =
             Assert.assertThrows(AuthorizationRequestExceptions.MissingInput::class.java) {
@@ -63,7 +63,7 @@ class InputDescriptorTest {
     fun `should throw invalid input exception if id param value is empty`(){
         presentationDefinition =
             """{"id":"pd_123","input_descriptors":[{"id":"","constraints":{"fields":[{"path":["$.type"]}]}}]}"""
-        expectedExceptionMessage = "Invalid Input: input_descriptor : id value cannot be empty or null"
+        expectedExceptionMessage = "Invalid Input: input_descriptor->id value cannot be empty or null"
 
         val actualException =
             Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptorTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptorTest.kt
@@ -63,7 +63,7 @@ class InputDescriptorTest {
     fun `should throw invalid input exception if id param value is empty`(){
         presentationDefinition =
             """{"id":"pd_123","input_descriptors":[{"id":"","constraints":{"fields":[{"path":["$.type"]}]}}]}"""
-        expectedExceptionMessage = "Invalid Input: input_descriptor->id value cannot be empty or null"
+        expectedExceptionMessage = "Invalid Input: input_descriptor->id value cannot be empty string, null or null string"
 
         val actualException =
             Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptorTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptorTest.kt
@@ -72,4 +72,18 @@ class InputDescriptorTest {
 
         Assert.assertEquals(expectedExceptionMessage, actualException.message)
     }
+
+    @Test
+    fun `should throw invalid input exception if id param value is present but it's value is null`(){
+        presentationDefinition =
+            """{"id":"pd_123","input_descriptors":[{"id":null,"constraints":{"fields":[{"path":["$.type"]}]}}]}"""
+        expectedExceptionMessage = "Invalid Input: input_descriptor->id value cannot be empty string, null or null string"
+
+        val actualException =
+            Assert.assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
+                deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
+            }
+
+        Assert.assertEquals(expectedExceptionMessage, actualException.message)
+    }
 }

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionTest.kt
@@ -68,7 +68,7 @@ class PresentationDefinitionTest {
     fun `should throw invalid input exception if id param value is empty`(){
         presentationDefinition =
             """{"id":"","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"]}]}}]}"""
-        expectedExceptionMessage = "Invalid Input: presentation_definition->id value cannot be empty or null"
+        expectedExceptionMessage = "Invalid Input: presentation_definition->id value cannot be empty string, null or null string"
 
         val actualException =
             assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
@@ -81,7 +81,7 @@ class PresentationDefinitionTest {
     @Test
     fun `should throw missing input exception if input_descriptor param value is empty`(){
         presentationDefinition = """{"id":"pd_123","input_descriptors":[]}"""
-        expectedExceptionMessage = "Invalid Input: presentation_definition->input_descriptors value cannot be empty or null"
+        expectedExceptionMessage = "Invalid Input: presentation_definition->input_descriptors value cannot be empty string, null or null string"
 
         val actualException =
             assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionTest.kt
@@ -68,7 +68,7 @@ class PresentationDefinitionTest {
     fun `should throw invalid input exception if id param value is empty`(){
         presentationDefinition =
             """{"id":"","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"]}]}}]}"""
-        expectedExceptionMessage = "Invalid Input: presentation_definition->id value cannot be empty string, null or null string"
+        expectedExceptionMessage = "Invalid Input: presentation_definition->id value cannot be empty string or null"
 
         val actualException =
             assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionTest.kt
@@ -90,4 +90,17 @@ class PresentationDefinitionTest {
 
         assertEquals(expectedExceptionMessage,actualException.message)
     }
+
+    @Test
+    fun `should throw invalid input exception if input_descriptor param value is present but it's value is null`(){
+        presentationDefinition = """{"id":"pd_123","input_descriptors":null}"""
+        expectedExceptionMessage = "Invalid Input: presentation_definition->input_descriptors value cannot be empty or null"
+
+        val actualException =
+            assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
+                deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
+            }
+
+        assertEquals(expectedExceptionMessage,actualException.message)
+    }
 }

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionTest.kt
@@ -38,7 +38,7 @@ class PresentationDefinitionTest {
     fun `should throw missing input exception if id param is missing`(){
         presentationDefinition =
             """{"input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"]}]}}]}"""
-        expectedExceptionMessage = "Missing Input: presentation_definition : id param is required"
+        expectedExceptionMessage = "Missing Input: presentation_definition->id param is required"
 
         val actualException =
             assertThrows(AuthorizationRequestExceptions.MissingInput::class.java) {
@@ -54,7 +54,7 @@ class PresentationDefinitionTest {
     @Test
     fun `should throw missing input exception if input_descriptor param is missing`(){
         presentationDefinition = """{"id":"pd_123"}"""
-        expectedExceptionMessage = "Missing Input: presentation_definition : input_descriptors param is required"
+        expectedExceptionMessage = "Missing Input: presentation_definition->input_descriptors param is required"
 
         val actualException =
             assertThrows(AuthorizationRequestExceptions.MissingInput::class.java) {
@@ -68,7 +68,7 @@ class PresentationDefinitionTest {
     fun `should throw invalid input exception if id param value is empty`(){
         presentationDefinition =
             """{"id":"","input_descriptors":[{"id":"id_123","constraints":{"fields":[{"path":["$.type"]}]}}]}"""
-        expectedExceptionMessage = "Invalid Input: presentation_definition : id value cannot be empty or null"
+        expectedExceptionMessage = "Invalid Input: presentation_definition->id value cannot be empty or null"
 
         val actualException =
             assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {
@@ -81,7 +81,7 @@ class PresentationDefinitionTest {
     @Test
     fun `should throw missing input exception if input_descriptor param value is empty`(){
         presentationDefinition = """{"id":"pd_123","input_descriptors":[]}"""
-        expectedExceptionMessage = "Invalid Input: presentation_definition : input_descriptors value cannot be empty or null"
+        expectedExceptionMessage = "Invalid Input: presentation_definition->input_descriptors value cannot be empty or null"
 
         val actualException =
             assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionTest.kt
@@ -52,7 +52,7 @@ class PresentationDefinitionTest {
     }
 
     @Test
-    fun `should throw missing input exception if input_descriptor param is missing`(){
+    fun `should throw missing input exception if input_descriptors param is missing`(){
         presentationDefinition = """{"id":"pd_123"}"""
         expectedExceptionMessage = "Missing Input: presentation_definition->input_descriptors param is required"
 
@@ -79,9 +79,9 @@ class PresentationDefinitionTest {
     }
 
     @Test
-    fun `should throw missing input exception if input_descriptor param value is empty`(){
+    fun `should throw invalid input exception if input_descriptor param value is empty`(){
         presentationDefinition = """{"id":"pd_123","input_descriptors":[]}"""
-        expectedExceptionMessage = "Invalid Input: presentation_definition->input_descriptors value cannot be empty string, null or null string"
+        expectedExceptionMessage = "Invalid Input: presentation_definition->input_descriptors value cannot be empty or null"
 
         val actualException =
             assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseTest.kt
@@ -60,7 +60,7 @@ class AuthorizationResponseTest {
         openID4VP = OpenID4VP("test-OpenID4VP")
         presentationDefinition =
             """{"id":"649d581c-f891-4969-9cd5-2c27385a348f","input_descriptors":[{"id":"id_123","format":{"ldp_vc":{"proof_type":["Ed25519Signature2018"]}},"constraints":{"fields":[{"path":["$.type"]}]}}]}"""
-        clientMetadata = """{"name": "verifier"}"""
+        clientMetadata = """{"client_name": "verifier"}"""
         trustedVerifiers = listOf(
             Verifier(
                 "https://injiverify.dev2.mosip.net", listOf(

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseTest.kt
@@ -122,7 +122,7 @@ class AuthorizationResponseTest {
         vpResponseMetadata = VPResponseMetadata(
             "eyJiweyrtwegrfwwaBKCGSwxjpa5suaMtgnQ", "RsaSignature2018", publicKey, ""
         )
-        expectedExceptionMessage = "Invalid Input: vp response metadata->domain value cannot be empty string, null or null string"
+        expectedExceptionMessage = "Invalid Input: vp response metadata->domain value cannot be empty string or null"
 
         actualException =
             assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseTest.kt
@@ -122,7 +122,7 @@ class AuthorizationResponseTest {
         vpResponseMetadata = VPResponseMetadata(
             "eyJiweyrtwegrfwwaBKCGSwxjpa5suaMtgnQ", "RsaSignature2018", publicKey, ""
         )
-        expectedExceptionMessage = "Invalid Input: domain value cannot be empty or null"
+        expectedExceptionMessage = "Invalid Input: vp response metadata->domain value cannot be empty or null"
 
         actualException =
             assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseTest.kt
@@ -122,7 +122,7 @@ class AuthorizationResponseTest {
         vpResponseMetadata = VPResponseMetadata(
             "eyJiweyrtwegrfwwaBKCGSwxjpa5suaMtgnQ", "RsaSignature2018", publicKey, ""
         )
-        expectedExceptionMessage = "Invalid Input: vp response metadata->domain value cannot be empty or null"
+        expectedExceptionMessage = "Invalid Input: vp response metadata->domain value cannot be empty string, null or null string"
 
         actualException =
             assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseTest.kt
@@ -172,8 +172,8 @@ class AuthorizationResponseTest {
     }
 
     @Test
-    fun `should return ok message if Authorization Response request call is made successfully and returned response with http status 200`() {
-        val mockResponse: MockResponse = MockResponse().setResponseCode(200)
+    fun `should get response if Verifiable Presentation is shared successfully to the Verifier`() {
+        val mockResponse: MockResponse = MockResponse().setResponseCode(200).setBody("Verifiable Presentation is shared successfully")
         mockWebServer.enqueue(mockResponse)
         vpResponseMetadata = VPResponseMetadata(
             "eyJiweyrtwegrfwwaBKCGSwxjpa5suaMtgnQ",
@@ -181,7 +181,7 @@ class AuthorizationResponseTest {
             publicKey,
             "https://123",
         )
-        val expectedValue = "OK"
+        val expectedValue = "Verifiable Presentation is shared successfully"
 
         val actualResponse = openID4VP.shareVerifiablePresentation(vpResponseMetadata)
 

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/common/DecoderTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/common/DecoderTest.kt
@@ -32,7 +32,7 @@ class DecoderTest {
     @Test
     fun `should throw invalid input exception for empty input`() {
         val encodedData = ""
-        val expectedExceptionMessage = "Invalid Input: encoded data value cannot be empty string, null or null string"
+        val expectedExceptionMessage = "Invalid Input: encoded data value cannot be empty string or null"
 
         val actualException =
             assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/common/DecoderTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/common/DecoderTest.kt
@@ -1,11 +1,33 @@
 package io.mosip.openID4VP.common
 
+import android.util.Log
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockkStatic
 import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
+import org.junit.Before
 import org.junit.Test
 
 class DecoderTest {
+
+    @Before
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.e(any(), any()) } answers {
+            val tag = arg<String>(0)
+            val msg = arg<String>(1)
+            println("Error: logTag: $tag | Message: $msg")
+            0
+        }
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
 
     @Test
     fun `should throw invalid input exception for empty input`() {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/common/DecoderTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/common/DecoderTest.kt
@@ -10,7 +10,7 @@ class DecoderTest {
     @Test
     fun `should throw invalid input exception for empty input`() {
         val encodedData = ""
-        val expectedExceptionMessage = "Invalid Input: encoded data value cannot be empty or null"
+        val expectedExceptionMessage = "Invalid Input: encoded data value cannot be empty string, null or null string"
 
         val actualException =
             assertThrows(AuthorizationRequestExceptions.InvalidInput::class.java) {

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/common/LoggerTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/common/LoggerTest.kt
@@ -50,10 +50,10 @@ class LoggerTest {
 	}
 
 	@Test
-	fun `should return invalid input exception if exception type input value is InvalidInput`() {
+	fun `should return invalid input exception if exception type input value is InvalidInput and field data is of type String`() {
 		expectedExceptionMessage = "Invalid Input: parent field name->current field name value cannot be empty string, null or null string"
 		actualException = Logger.handleException(
-			exceptionType = "InvalidInput", fieldPath = listOf("parent field name", "current field name"), className = javaClass.simpleName
+			exceptionType = "InvalidInput", fieldPath = listOf("parent field name", "current field name"), className = javaClass.simpleName, fieldType = "String"
 		)
 
 		assertEquals(expectedExceptionMessage,actualException.message)

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/common/LoggerTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/common/LoggerTest.kt
@@ -51,7 +51,7 @@ class LoggerTest {
 
 	@Test
 	fun `should return invalid input exception if exception type input value is InvalidInput`() {
-		expectedExceptionMessage = "Invalid Input: parent field name->current field name value cannot be empty or null"
+		expectedExceptionMessage = "Invalid Input: parent field name->current field name value cannot be empty string, null or null string"
 		actualException = Logger.handleException(
 			exceptionType = "InvalidInput", fieldPath = listOf("parent field name", "current field name"), className = javaClass.simpleName
 		)

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/common/LoggerTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/common/LoggerTest.kt
@@ -51,7 +51,7 @@ class LoggerTest {
 
 	@Test
 	fun `should return invalid input exception if exception type input value is InvalidInput and field data is of type String`() {
-		expectedExceptionMessage = "Invalid Input: parent field name->current field name value cannot be empty string, null or null string"
+		expectedExceptionMessage = "Invalid Input: parent field name->current field name value cannot be empty string or null"
 		actualException = Logger.handleException(
 			exceptionType = "InvalidInput", fieldPath = listOf("parent field name", "current field name"), className = javaClass.simpleName, fieldType = "String"
 		)

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/common/LoggerTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/common/LoggerTest.kt
@@ -23,7 +23,7 @@ class LoggerTest {
 			println("Error: logTag: $tag | Message: $msg")
 			0
 		}
-		Logger.setTraceability("test-openId4VP")
+		Logger.setTraceabilityId("test-openId4VP")
 	}
 
 	@After
@@ -41,9 +41,9 @@ class LoggerTest {
 
 	@Test
 	fun `should return missing input exception if exception type input value is MissingInput`() {
-		expectedExceptionMessage = "Missing Input: parent field name : current field name param is required"
+		expectedExceptionMessage = "Missing Input: parent field name->current field name param is required"
 		actualException = Logger.handleException(
-			"MissingInput", "parent field name", "current field name", javaClass.simpleName
+			exceptionType = "MissingInput", fieldPath = listOf("parent field name", "current field name"), className = javaClass.simpleName
 		)
 
 		assertEquals(expectedExceptionMessage,actualException.message)
@@ -51,9 +51,9 @@ class LoggerTest {
 
 	@Test
 	fun `should return invalid input exception if exception type input value is InvalidInput`() {
-		expectedExceptionMessage = "Invalid Input: parent field name : current field name value cannot be empty or null"
+		expectedExceptionMessage = "Invalid Input: parent field name->current field name value cannot be empty or null"
 		actualException = Logger.handleException(
-			"InvalidInput", "parent field name", "current field name", javaClass.simpleName
+			exceptionType = "InvalidInput", fieldPath = listOf("parent field name", "current field name"), className = javaClass.simpleName
 		)
 
 		assertEquals(expectedExceptionMessage,actualException.message)
@@ -61,9 +61,9 @@ class LoggerTest {
 
 	@Test
 	fun `should return invalid input pattern exception if exception type input value is InvalidInputPattern`() {
-		expectedExceptionMessage = "Invalid Input Pattern: parent field name : current field name pattern is not matching with OpenId4VP specification"
+		expectedExceptionMessage = "Invalid Input Pattern: parent field name->current field name pattern is not matching with OpenId4VP specification"
 		actualException = Logger.handleException(
-			"InvalidInputPattern", "parent field name", "current field name", javaClass.simpleName
+			exceptionType = "InvalidInputPattern", fieldPath = listOf("parent field name", "current field name"), className = javaClass.simpleName
 		)
 
 		assertEquals(expectedExceptionMessage,actualException.message)


### PR DESCRIPTION
- Added support to fetch the presentation_definition json object by calling the presentation_definition_uri end-point of verifier
- Added support to return the logo_url received in the Verifier Authorization Request to the wallet
- Enhanced the handleException method of the Logger class to handle the exceptions in better way and to remove redundant lines of code