### PR TITLE
[INJIMOB-3191]:OVP error handling

### DIFF
--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestUtils.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestUtils.kt
@@ -8,6 +8,7 @@ import io.mosip.openID4VP.constants.ClientIdScheme.PRE_REGISTERED
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.common.getStringValue
 import io.mosip.openID4VP.common.validate
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 
@@ -41,11 +42,7 @@ fun getAuthorizationRequestHandler(
             walletMetadata,
             setResponseUri
         )
-        else -> throw Logger.handleException(
-            exceptionType = "InvalidData",
-            className = className,
-            message = "Given client_id_scheme is not supported"
-        )
+        else -> throw OpenID4VPExceptions.InvalidData("Given client_id_scheme is not supported", className)
     }
 }
 
@@ -55,11 +52,7 @@ fun extractQueryParameters(query: String): MutableMap<String, Any> {
         return urlDecodedQueryString.split("&").map { it.split("=") }
             .associateByTo(mutableMapOf(), { it[0] }, { it[1] })
     } catch (exception: Exception) {
-        throw Logger.handleException(
-            exceptionType = "InvalidQueryParams",
-            message = "Exception occurred when extracting the query params from Authorization Request : ${exception.message}",
-            className = className
-        )
+        throw  OpenID4VPExceptions.InvalidQueryParams("Exception occurred when extracting the query params from Authorization Request : ${exception.message}", className)
     }
 }
 
@@ -68,18 +61,11 @@ fun validateAuthorizationRequestObjectAndParameters(
     authorizationRequestObject: Map<String, Any>,
 ) {
     if (params[CLIENT_ID.value] != authorizationRequestObject[CLIENT_ID.value]) {
-        throw Logger.handleException(
-            exceptionType = "InvalidData",
-            message = "Client Id mismatch in Authorization Request parameter and the Request Object",
-            className = className
-        )
+        throw  OpenID4VPExceptions.InvalidData("Client Id mismatch in Authorization Request parameter and the Request Object",
+            className)
     }
     if(params.containsKey(CLIENT_ID_SCHEME.value) && params[CLIENT_ID_SCHEME.value] != authorizationRequestObject[CLIENT_ID_SCHEME.value]) {
-        throw Logger.handleException(
-            exceptionType = "InvalidData",
-            message = "Client Id Scheme mismatch in Authorization Request parameter and the Request Object",
-            className = className
-        )
+        throw  OpenID4VPExceptions.InvalidData("Client Id Scheme mismatch in Authorization Request parameter and the Request Object", className)
     }
 }
 

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/WalletMetadata.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/WalletMetadata.kt
@@ -3,6 +3,7 @@ package io.mosip.openID4VP.authorizationRequest
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.constants.ClientIdScheme
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 
 private val className = WalletMetadata::class.simpleName!!
 
@@ -18,18 +19,10 @@ data class WalletMetadata(
 ){
     init {
         require(vpFormatsSupported.isNotEmpty()) {
-            throw Logger.handleException(
-                exceptionType = "InvalidData",
-                className = className,
-                message = "vp_formats_supported should at least have one supported vp_format"
-            )
+            throw OpenID4VPExceptions.InvalidData("vp_formats_supported should at least have one supported vp_format", className)
         }
         require(vpFormatsSupported.keys.all { it.trim().isNotEmpty() }) {
-            throw Logger.handleException(
-                exceptionType = "InvalidData",
-                className = className,
-                message = "vp_formats_supported cannot have empty keys"
-            )
+            throw OpenID4VPExceptions.InvalidData("vp_formats_supported cannot have empty keys", className)
         }
     }
     constructor(

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestHandler.kt
@@ -17,6 +17,7 @@ import io.mosip.openID4VP.common.validate
 import io.mosip.openID4VP.constants.HttpMethod
 import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandlerFactory
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 
 private val className = ClientIdSchemeBasedAuthorizationRequestHandler::class.simpleName!!
 
@@ -35,11 +36,7 @@ abstract class ClientIdSchemeBasedAuthorizationRequestHandler(
         var requestUriResponse: Map<String, Any> = emptyMap()
         getStringValue(authorizationRequestParameters, REQUEST_URI.value)?.let { requestUri ->
             if (!isValidUrl(requestUri))
-                throw Logger.handleException(
-                    exceptionType = "InvalidData",
-                    className = className,
-                    message = "${REQUEST_URI.value} data is not valid"
-                )
+                throw OpenID4VPExceptions.InvalidData("${REQUEST_URI.value} data is not valid", className)
             val requestUriMethod =
                 getStringValue(authorizationRequestParameters, REQUEST_URI_METHOD.value) ?: "get"
             val httpMethod = determineHttpMethod(requestUriMethod)
@@ -77,11 +74,7 @@ abstract class ClientIdSchemeBasedAuthorizationRequestHandler(
 
     fun setResponseUrl() {
         val responseMode = getStringValue(authorizationRequestParameters, RESPONSE_MODE.value)
-            ?: throw Logger.handleException(
-                exceptionType = "MissingInput",
-                className = className,
-                fieldPath = listOf(RESPONSE_MODE.value)
-            )
+            ?: throw  OpenID4VPExceptions.MissingInput(listOf(RESPONSE_MODE.value),"", className)
         ResponseModeBasedHandlerFactory.get(responseMode)
             .setResponseUrl(authorizationRequestParameters, setResponseUri)
     }
@@ -104,11 +97,7 @@ abstract class ClientIdSchemeBasedAuthorizationRequestHandler(
     private fun isClientIdSchemeSupported(walletMetadata: WalletMetadata) {
         val clientIdScheme = extractClientIdScheme(authorizationRequestParameters)
         if (!walletMetadata.clientIdSchemesSupported.contains(clientIdScheme))
-            throw Logger.handleException(
-                exceptionType = "InvalidData",
-                className = className,
-                message = "client_id_scheme is not support by wallet"
-            )
+            throw OpenID4VPExceptions.InvalidData("client_id_scheme is not support by wallet", className)
 
     }
 

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/DidSchemeAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/DidSchemeAuthorizationRequestHandler.kt
@@ -8,6 +8,7 @@ import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.common.getStringValue
 import io.mosip.openID4VP.common.isJWS
 import io.mosip.openID4VP.constants.ContentType.APPLICATION_FORM_URL_ENCODED
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.jwt.jws.JWSHandler
 import io.mosip.openID4VP.jwt.jws.JWSHandler.JwsPart.HEADER
 import io.mosip.openID4VP.jwt.jws.JWSHandler.JwsPart.PAYLOAD
@@ -48,26 +49,15 @@ class DidSchemeAuthorizationRequestHandler(
                 authorizationRequestParameters = authorizationRequestObject
 
             } else
-                throw Logger.handleException(
-                    exceptionType = "InvalidData",
-                    className = className,
-                    message = "Authorization Request must be signed for given client_id_scheme"
-                )
+                throw OpenID4VPExceptions.InvalidData("Authorization Request must be signed for given client_id_scheme",
+                    className)
+        } else  throw OpenID4VPExceptions.MissingInput(listOf(REQUEST_URI.value),"", className)
 
-        } else  throw Logger.handleException(
-            exceptionType = "MissingInput",
-            className = className,
-            fieldPath = listOf(REQUEST_URI.value),
-        )
     }
 
     override fun process(walletMetadata: WalletMetadata): WalletMetadata {
         if(walletMetadata.requestObjectSigningAlgValuesSupported.isNullOrEmpty())
-            throw Logger.handleException(
-                exceptionType = "InvalidData",
-                className = className,
-                message = "request_object_signing_alg_values_supported is not present in wallet metadata"
-            )
+            throw  OpenID4VPExceptions.InvalidData("request_object_signing_alg_values_supported is not present in wallet metadata",className)
         return walletMetadata
     }
 
@@ -86,11 +76,7 @@ class DidSchemeAuthorizationRequestHandler(
             val alg = headers["alg"]
             walletMetadata?.let {
                 if (!it.requestObjectSigningAlgValuesSupported!!.contains(alg))
-                    throw Logger.handleException(
-                        exceptionType = "InvalidData",
-                        className = className,
-                        message = "request_object_signing_alg is not support by wallet"
-                    )
+                    throw OpenID4VPExceptions.InvalidData("request_object_signing_alg is not support by wallet", className)
             }
         }
     }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandler.kt
@@ -12,6 +12,7 @@ import io.mosip.openID4VP.authorizationRequest.Verifier
 import io.mosip.openID4VP.authorizationRequest.extractClientIdentifier
 import io.mosip.openID4VP.constants.ContentType.APPLICATION_JSON
 import okhttp3.Headers
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 
 private val className = PreRegisteredSchemeAuthorizationRequestHandler::class.simpleName!!
 
@@ -27,11 +28,7 @@ class PreRegisteredSchemeAuthorizationRequestHandler(
 
         val clientId =  getStringValue(authorizationRequestParameters, CLIENT_ID.value)!!
         if (trustedVerifiers.none { it.clientId == clientId }) {
-            throw Logger.handleException(
-                exceptionType = "InvalidVerifier",
-                className = className,
-                message = "Verifier is not trusted by the wallet"
-            )
+            throw  OpenID4VPExceptions.InvalidVerifier("Verifier is not trusted by the wallet", className)
         }
     }
 
@@ -53,11 +50,7 @@ class PreRegisteredSchemeAuthorizationRequestHandler(
                 )
                 authorizationRequestObject
             } else {
-                throw Logger.handleException(
-                    exceptionType = "InvalidData",
-                    className = className,
-                    message = "Authorization Request must not be signed for given client_id_scheme"
-                )
+                throw OpenID4VPExceptions.InvalidData("Authorization Request must not be signed for given client_id_scheme", className)
             }
         }
     }
@@ -84,11 +77,7 @@ class PreRegisteredSchemeAuthorizationRequestHandler(
         val responseUri = getStringValue(authorizationRequestParameters, RESPONSE_URI.value)!!
 
         if (trustedVerifiers.none { it.clientId == clientId && it.responseUris.contains(responseUri) }) {
-            throw Logger.handleException(
-                exceptionType = "InvalidVerifier",
-                className = className,
-                message = "Verifier is not trusted by the wallet"
-            )
+            throw OpenID4VPExceptions.InvalidVerifier("Verifier is not trusted by the wallet", className)
         }
 
     }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriSchemeAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriSchemeAuthorizationRequestHandler.kt
@@ -14,6 +14,7 @@ import io.mosip.openID4VP.common.validate
 import io.mosip.openID4VP.constants.ContentType
 import io.mosip.openID4VP.constants.ContentType.APPLICATION_FORM_URL_ENCODED
 import okhttp3.Headers
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 
 private val className = RedirectUriSchemeAuthorizationRequestHandler::class.simpleName!!
 
@@ -40,11 +41,7 @@ class RedirectUriSchemeAuthorizationRequestHandler(
                 )
                 authorizationRequestObject
             } else {
-                throw Logger.handleException(
-                    exceptionType = "InvalidData",
-                    className = className,
-                    message = "Authorization Request must not be signed for given client_id_scheme"
-                )
+                throw OpenID4VPExceptions.InvalidData("Authorization Request must not be signed for given client_id_scheme", className)
             }
         }
     }
@@ -65,11 +62,7 @@ class RedirectUriSchemeAuthorizationRequestHandler(
     override fun validateAndParseRequestFields(){
         super.validateAndParseRequestFields()
         val responseMode = getStringValue(authorizationRequestParameters, RESPONSE_MODE.value) ?:
-        throw Logger.handleException(
-            exceptionType = "MissingInput",
-            className = className,
-            fieldPath = listOf(RESPONSE_MODE.value)
-        )
+        throw OpenID4VPExceptions.MissingInput(listOf(RESPONSE_MODE.value),"", className)
          when (responseMode) {
             DIRECT_POST.value, DIRECT_POST_JWT.value -> {
                 validateUriCombinations(
@@ -78,11 +71,7 @@ class RedirectUriSchemeAuthorizationRequestHandler(
                     REDIRECT_URI.value
                 )
             }
-            else -> throw Logger.handleException(
-                exceptionType = "InvalidData",
-                className = className,
-                message = "Given response_mode is not supported"
-            )
+            else -> throw OpenID4VPExceptions.InvalidData("Given response_mode is not supported", className)
         }
     }
 
@@ -93,11 +82,7 @@ class RedirectUriSchemeAuthorizationRequestHandler(
     )  {
         when {
             authRequestParam.containsKey(inValidAttribute) -> {
-                throw Logger.handleException(
-                    exceptionType = "InvalidData",
-                    className = className,
-                    message = "$inValidAttribute should not be present for given response_mode"
-                )
+                throw OpenID4VPExceptions.InvalidData("$inValidAttribute should not be present for given response_mode", className)
             }
             else -> {
                 val data = getStringValue(authRequestParam, validAttribute)
@@ -105,11 +90,7 @@ class RedirectUriSchemeAuthorizationRequestHandler(
             }
         }
         if(authRequestParam[validAttribute] != extractClientIdentifier(authRequestParam))
-            throw Logger.handleException(
-                exceptionType = "InvalidData",
-                className = className,
-                message = "$validAttribute should be equal to client_id for given client_id_scheme"
-            )
+            throw OpenID4VPExceptions.InvalidData("$validAttribute should be equal to client_id for given client_id_scheme", className)
 
     }
 

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/clientMetadata/ClientMetadata.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/clientMetadata/ClientMetadata.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.jsonObject
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 
 private val className = ClientMetadata::class.simpleName!!
 
@@ -35,12 +36,9 @@ object ClientMetadataSerializer : KSerializer<ClientMetadata> {
 		val jsonDecoder = try {
 			decoder as JsonDecoder
 		} catch (e: ClassCastException) {
-			throw Logger.handleException(
-				exceptionType = "DeserializationFailure",
-				fieldPath = listOf(CLIENT_METADATA.value),
-				message = e.message!!,
-				className = className
-			)
+			throw  OpenID4VPExceptions.DeserializationFailure(
+				listOf(CLIENT_METADATA.value),e.message!!,
+				className)
 		}
 		val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
 		val deserializer = FieldDeserializer(
@@ -57,12 +55,7 @@ object ClientMetadataSerializer : KSerializer<ClientMetadata> {
 			deserializer.deserializeField<Map<String, Map<String, List<String>>>>(
 				key = "vp_formats",
 				fieldType = "Map"
-			) ?: throw Logger.handleException(
-				exceptionType = "InvalidInput",
-				fieldPath = listOf(CLIENT_METADATA.value, "vp_formats"),
-				className = className,
-				fieldType = "map"
-			)
+			) ?: throw  OpenID4VPExceptions.InvalidInput(listOf(CLIENT_METADATA.value),"map",className)
 		val authorizationEncryptedResponseAlg: String? =
 			deserializer.deserializeField(key = "authorization_encrypted_response_alg", fieldType = "String")
 		val authorizationEncryptedResponseEnc: String? =
@@ -131,12 +124,8 @@ class ClientMetadata(
 ) : Validatable {
 	override fun validate() {
 		if(vpFormats.isEmpty())	{
-			throw Logger.handleException(
-				exceptionType = "InvalidInput",
-				fieldPath = listOf(CLIENT_METADATA.value, "vp_formats"),
-				className = className,
-				fieldType = "map"
-			)
+			throw OpenID4VPExceptions.InvalidInput(listOf(CLIENT_METADATA.value,"vp_formats"),"map",
+				className)
 		}
 		return
 	}

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/clientMetadata/ClientMetadataUtil.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/clientMetadata/ClientMetadataUtil.kt
@@ -6,6 +6,7 @@ import io.mosip.openID4VP.authorizationRequest.WalletMetadata
 import io.mosip.openID4VP.authorizationRequest.deserializeAndValidate
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.common.getStringValue
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandlerFactory
 
 private val className = ClientMetadata::class.simpleName!!
@@ -22,11 +23,7 @@ fun parseAndValidateClientMetadata(
                 ClientMetadataSerializer
             )
 
-            else -> throw Logger.handleException(
-                exceptionType = "InvalidData",
-                message = "client_metadata must be of type String or Map",
-                className = className
-            )
+            else -> throw OpenID4VPExceptions.InvalidData("client_metadata must be of type String or Map", className)
         }
     }
     val responseMode = getStringValue(

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/clientMetadata/Jwk.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/clientMetadata/Jwk.kt
@@ -3,6 +3,7 @@ package io.mosip.openID4VP.authorizationRequest.clientMetadata
 import Generated
 import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.common.Logger
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -31,12 +32,7 @@ object JwkSerializer : KSerializer<Jwk> {
         val jsonDecoder = try {
             decoder as JsonDecoder
         } catch (e: ClassCastException) {
-            throw Logger.handleException(
-                exceptionType = "DeserializationFailure",
-                fieldPath = listOf("jwk"),
-                message = e.message!!,
-                className = className
-            )
+            throw  OpenID4VPExceptions.DeserializationFailure(listOf("jwk"),e.message!!, className)
         }
 
         val jsonObject = jsonDecoder.decodeJsonElement().jsonObject

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/clientMetadata/Jwks.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/clientMetadata/Jwks.kt
@@ -4,6 +4,7 @@ import Generated
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.FieldsSerializer
 import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.common.Logger
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
@@ -26,12 +27,7 @@ object JwksSerializer : KSerializer<Jwks> {
         val jsonDecoder = try {
             decoder as JsonDecoder
         } catch (e: ClassCastException) {
-            throw Logger.handleException(
-                exceptionType = "DeserializationFailure",
-                fieldPath = listOf("jwk"),
-                message = e.message!!,
-                className = className
-            )
+            throw OpenID4VPExceptions.DeserializationFailure( listOf("jwk"),e.message!!, className )
         }
         val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
         val deserializer = FieldDeserializer(

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Constraints.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Constraints.kt
@@ -3,6 +3,7 @@ package io.mosip.openID4VP.authorizationRequest.presentationDefinition
 import Generated
 import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.common.Logger
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -26,12 +27,8 @@ object ConstraintsSerializer : KSerializer<Constraints> {
 		val jsonDecoder = try {
 			decoder as JsonDecoder
 		} catch (e: ClassCastException) {
-			throw Logger.handleException(
-				exceptionType = "DeserializationFailure",
-				fieldPath = listOf("constraints"),
-				message = e.message!!,
-				className = className
-			)
+			throw OpenID4VPExceptions.DeserializationFailure( listOf("constraints"),e.message!!,
+				className)
 		}
 
 		val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
@@ -83,10 +80,7 @@ class Constraints(
 
 			limitDisclosure?.let {
 				LimitDisclosure.entries.firstOrNull { it.value == limitDisclosure }
-					?: throw Logger.handleException(
-						exceptionType = "InvalidLimitDisclosure",
-						className = className
-					)
+					?: throw OpenID4VPExceptions.InvalidLimitDisclosure(className)
 			}
 		} catch (exception: Exception) {
 			throw exception

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Fields.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Fields.kt
@@ -3,6 +3,7 @@ package io.mosip.openID4VP.authorizationRequest.presentationDefinition
 import Generated
 import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.common.Logger
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
@@ -31,12 +32,7 @@ object FieldsSerializer : KSerializer<Fields> {
 		val jsonDecoder = try {
 			decoder as JsonDecoder
 		} catch (e: ClassCastException) {
-			throw Logger.handleException(
-				exceptionType = "DeserializationFailure",
-				fieldPath = listOf("fields"),
-				message = e.message!!,
-				className = className
-			)
+			throw OpenID4VPExceptions.DeserializationFailure(listOf("fields"),e.message!!, className)
 		}
 		val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
 		val deserializer = FieldDeserializer(
@@ -112,11 +108,7 @@ class Fields(
 			path.forEach { p ->
 				val isNotValidPrefix = !(pathPrefixes.any { p.startsWith(it) })
 				if (isNotValidPrefix) {
-					throw Logger.handleException(
-						exceptionType = "InvalidInputPattern",
-						fieldPath = listOf("fields", "path"),
-						className = className,
-					)
+					throw OpenID4VPExceptions.InvalidInputPattern(listOf("fields","path"), className)
 				}
 			}
 		} catch (exception: Exception) {

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Filter.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/Filter.kt
@@ -3,6 +3,7 @@ package io.mosip.openID4VP.authorizationRequest.presentationDefinition
 import Generated
 import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.common.Logger
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -25,12 +26,7 @@ object FilterSerializer : KSerializer<Filter> {
 		val jsonDecoder = try {
 			decoder as JsonDecoder
 		} catch (e: ClassCastException) {
-			throw Logger.handleException(
-				exceptionType = "DeserializationFailure",
-				fieldPath = listOf("filter"),
-				message = e.message!!,
-				className = className
-			)
+			throw OpenID4VPExceptions.DeserializationFailure(listOf("filter"),e.message!!, className)
 		}
 		val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
 		val deserializer = FieldDeserializer(

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptor.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptor.kt
@@ -4,6 +4,7 @@ import Generated
 import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.exceptions.Exceptions
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
@@ -31,12 +32,8 @@ object InputDescriptorSerializer : KSerializer<InputDescriptor> {
 		val jsonDecoder = try {
 			decoder as JsonDecoder
 		} catch (e: ClassCastException) {
-			throw Logger.handleException(
-				exceptionType = "DeserializationFailure",
-				fieldPath = listOf("input_descriptor"),
-				message = e.message!!,
-				className = className
-			)
+			throw  OpenID4VPExceptions.DeserializationFailure(listOf("input_descriptor"),e.message!!,
+				className)
 		}
 		val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
 		val deserializer = FieldDeserializer(

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinition.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinition.kt
@@ -6,6 +6,7 @@ import io.mosip.openID4VP.authorizationRequest.Validatable
 import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.exceptions.Exceptions
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -36,12 +37,8 @@ object PresentationDefinitionSerializer : KSerializer<PresentationDefinition> {
 		val jsonDecoder = try {
 			decoder as JsonDecoder
 		} catch (e: ClassCastException) {
-			throw Logger.handleException(
-				exceptionType = "DeserializationFailure",
-				fieldPath = listOf(PRESENTATION_DEFINITION.value),
-				message = e.message!!,
-				className = className
-			)
+			throw OpenID4VPExceptions.DeserializationFailure(listOf(PRESENTATION_DEFINITION.value),e.message!!,
+				className)
 		}
 		val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
 		val deserializer = FieldDeserializer(

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionUtil.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionUtil.kt
@@ -5,11 +5,13 @@ import io.mosip.openID4VP.authorizationRequest.AuthorizationRequestFieldConstant
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequestFieldConstants.RESPONSE_MODE
 import io.mosip.openID4VP.authorizationRequest.deserializeAndValidate
 import io.mosip.openID4VP.common.Logger
+import io.mosip.openID4VP.common.OpenID4VPErrorCodes
 import io.mosip.openID4VP.common.getStringValue
 import io.mosip.openID4VP.common.isValidUrl
 import io.mosip.openID4VP.common.validate
 import io.mosip.openID4VP.constants.HttpMethod
 import io.mosip.openID4VP.constants.ResponseMode
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
 
 private val className = PresentationDefinition::class.simpleName!!
@@ -25,11 +27,8 @@ fun parseAndValidatePresentationDefinition(
 
     when {
         hasPresentationDefinition && hasPresentationDefinitionUri -> {
-            throw Logger.handleException(
-                exceptionType = "InvalidData",
-                message = "Either presentation_definition or presentation_definition_uri request param can be provided but not both",
-                className = className
-            )
+            throw OpenID4VPExceptions.InvalidData("Either presentation_definition or presentation_definition_uri request param can be provided but not both",
+                className)
         }
 
         hasPresentationDefinition -> {
@@ -39,11 +38,7 @@ fun parseAndValidatePresentationDefinition(
 
         hasPresentationDefinitionUri -> {
             if (!isPresentationDefinitionUriSupported) {
-                throw Logger.handleException(
-                    exceptionType = "InvalidData",
-                    className = className,
-                    message = "presentation_definition_uri is not support"
-                )
+                throw  OpenID4VPExceptions.InvalidData("presentation_definition_uri is not support",OpenID4VPErrorCodes.INVALID_PRESENTATION_DEFINITION_URI)
             }
 
             val presentationDefinitionUri = getStringValue(
@@ -52,11 +47,7 @@ fun parseAndValidatePresentationDefinition(
             )
             validate(PRESENTATION_DEFINITION_URI.value, presentationDefinitionUri, className)
             if (!isValidUrl(presentationDefinitionUri!!)) {
-                throw Logger.handleException(
-                    exceptionType = "InvalidData",
-                    className = className,
-                    message = "${PRESENTATION_DEFINITION_URI.value} data is not valid"
-                )
+                throw OpenID4VPExceptions.InvalidData("${PRESENTATION_DEFINITION_URI.value} data is not valid", className,OpenID4VPErrorCodes.INVALID_PRESENTATION_DEFINITION_REFERENCE)
             }
             val response =
                 sendHTTPRequest(
@@ -67,11 +58,7 @@ fun parseAndValidatePresentationDefinition(
         }
 
         else -> {
-            throw Logger.handleException(
-                exceptionType = "InvalidData",
-                message = "Either presentation_definition or presentation_definition_uri request param must be present",
-                className = className
-            )
+            throw  OpenID4VPExceptions.InvalidData("Either presentation_definition or presentation_definition_uri request param must be present", className)
         }
     }
 
@@ -86,11 +73,8 @@ fun parseAndValidatePresentationDefinition(
             PresentationDefinitionSerializer
         )
 
-        else -> throw Logger.handleException(
-            exceptionType = "InvalidData",
-            message = "presentation_definition must be of type String or Map ",
-            className = className
-        )
+        else -> throw  OpenID4VPExceptions.InvalidData("presentation_definition must be of type String or Map",
+            className)
     }
 
     authorizationRequestParameters[PRESENTATION_DEFINITION.value] = presentationDefinitionObj
@@ -112,10 +96,7 @@ private fun validateResponseModeForMsoMdocFormat(presentationDefinitionObj: Pres
             }
 
     if (hasMsoMdocFormat && responseMode != ResponseMode.DIRECT_POST_JWT.value) {
-        throw Logger.handleException(
-            exceptionType = "InvalidData",
-            className = className,
-            message = "When mso_mdoc format is present in presentation definition, response_mode must be direct_post.jwt"
-        )
+        throw OpenID4VPExceptions.InvalidData("When mso_mdoc format is present in presentation definition, response_mode must be direct_post.jwt", className)
+
     }
 }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
@@ -20,6 +20,7 @@ import io.mosip.openID4VP.constants.VPFormatType
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.UnsignedLdpVPTokenBuilder
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.mdoc.UnsignedMdocVPTokenBuilder
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandlerFactory
 
 private val className = AuthorizationResponseHandler::class.java.simpleName
@@ -35,11 +36,7 @@ internal class AuthorizationResponseHandler {
         responseUri: String,
     ): Map<FormatType, UnsignedVPToken> {
         if (credentialsMap.isEmpty()) {
-            throw Logger.handleException(
-                exceptionType = "InvalidData",
-                className = className,
-                message = "Empty credentials list - The Wallet did not have the requested Credentials to satisfy the Authorization Request."
-            )
+            throw OpenID4VPExceptions.InvalidData("Empty credentials list - The Wallet did not have the requested Credentials to satisfy the Authorization Request.", className)
         }
         this.credentialsMap = credentialsMap
         this.unsignedVPTokens = createUnsignedVPTokens(authorizationRequest, responseUri)
@@ -87,11 +84,7 @@ internal class AuthorizationResponseHandler {
                 )
             }
 
-            else -> throw Logger.handleException(
-                exceptionType = "InvalidData",
-                className = className,
-                message = "Provided response_type - ${authorizationRequest.responseType} is not supported"
-            )
+            else -> throw  OpenID4VPExceptions.InvalidData("Provided response_type - ${authorizationRequest.responseType} is not supported", className)
         }
     }
 
@@ -128,11 +121,7 @@ internal class AuthorizationResponseHandler {
                 VPTokenFactory(
                     vpTokenSigningResult = vpTokenSigningResult,
                     unsignedVPToken = unsignedVPTokens[credentialFormat]
-                        ?: throw Logger.handleException(
-                            exceptionType = "InvalidData",
-                            message = "unable to find the related credential format - $credentialFormat in the unsignedVPTokens map",
-                            className = className
-                        ),
+                        ?: throw OpenID4VPExceptions.InvalidData("unable to find the related credential format - $credentialFormat in the unsignedVPTokens map", className),
                     credentials = groupedVcs[credentialFormat],
                     nonce = authorizationRequest.nonce
                 ).getVPTokenBuilder(credentialFormat).build()

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationResponse/unsignedVPToken/types/mdoc/UnsignedMdocVPTokenBuilder.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationResponse/unsignedVPToken/types/mdoc/UnsignedMdocVPTokenBuilder.kt
@@ -12,6 +12,7 @@ import io.mosip.openID4VP.common.encodeCbor
 import io.mosip.openID4VP.common.getDecodedMdocCredential
 import io.mosip.openID4VP.common.tagEncodedCbor
 import io.mosip.openID4VP.common.toHex
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 
 private val classname = UnsignedMdocVPToken::class.simpleName!!
 class UnsignedMdocVPTokenBuilder(
@@ -47,11 +48,7 @@ class UnsignedMdocVPTokenBuilder(
             )
             val deviceAuthenticationBytes = tagEncodedCbor(deviceAuthentication)
             if (docTypeToDeviceAuthenticationBytes.containsKey(docType)) {
-                throw Logger.handleException(
-                    exceptionType = "InvalidData",
-                    message = "Duplicate Mdoc Credentials with same doctype found",
-                    className = classname
-                )
+                throw OpenID4VPExceptions.InvalidData("Duplicate Mdoc Credentials with same doctype found", classname)
             }
             docTypeToDeviceAuthenticationBytes[docType] = encodeCbor(deviceAuthenticationBytes).toHex()
 

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationResponse/vpToken/types/mdoc/MdocVPTokenBuilder.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationResponse/vpToken/types/mdoc/MdocVPTokenBuilder.kt
@@ -15,6 +15,7 @@ import io.mosip.openID4VP.common.getDecodedMdocCredential
 import io.mosip.openID4VP.common.mapSigningAlgorithmToProtectedAlg
 import io.mosip.openID4VP.common.tagEncodedCbor
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.mdoc.MdocVPTokenSigningResult
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 
 private val className = MdocVPTokenBuilder::class.java.simpleName
 
@@ -72,11 +73,7 @@ class MdocVPTokenBuilder(
     }
 
     private fun throwMissingInput(message: String): Nothing {
-        throw Logger.handleException(
-            exceptionType = "MissingInput",
-            message = message,
-            className = className
-        )
+        throw OpenID4VPExceptions.MissingInput("",message, className)
     }
 }
 

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationResponse/vpTokenSigningResult/types/ldp/LdpVPTokenSigningResult.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationResponse/vpTokenSigningResult/types/ldp/LdpVPTokenSigningResult.kt
@@ -3,6 +3,7 @@ package io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.common.validateField
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 
 private val className = LdpVPTokenSigningResult::class.simpleName!!
 
@@ -22,12 +23,7 @@ data class LdpVPTokenSigningResult(
 
         requiredParams.forEach { (key, value) ->
             require(value != "null" && validateField(value, "String")) {
-                throw Logger.handleException(
-                    exceptionType = "InvalidInput",
-                    fieldPath = listOf("ldp_vp_token_signing_result", key),
-                    className = className,
-                    fieldType = key::class.simpleName
-                )
+                throw OpenID4VPExceptions.InvalidInput(listOf("ldp_vp_token_signing_result", key),key::class.simpleName, className)
             }
         }
     }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationResponse/vpTokenSigningResult/types/mdoc/DeviceAuthentication.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/authorizationResponse/vpTokenSigningResult/types/mdoc/DeviceAuthentication.kt
@@ -2,6 +2,7 @@ package io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.mdoc
 
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.common.validateField
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 
 private val className = DeviceAuthentication::class.simpleName!!
 
@@ -13,12 +14,8 @@ data class DeviceAuthentication(
         val requiredParams = mapOf("signature" to signature, "algorithm" to algorithm)
         requiredParams.forEach { (key, value) ->
             require(value != "null" && validateField(value, "String")) {
-                throw Logger.handleException(
-                    exceptionType = "InvalidInput",
-                    fieldPath = listOf("mdoc_vp_token_signing_result","device_authentication", key),
-                    className = className,
-                    fieldType = key
-                )
+                throw  OpenID4VPExceptions.InvalidInput(listOf("mdoc_vp_token_signing_result","device_authentication", key),key,
+                    className)
             }
         }
     }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/FieldDeserializer.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/FieldDeserializer.kt
@@ -1,5 +1,6 @@
 package io.mosip.openID4VP.common
 
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
@@ -33,18 +34,10 @@ class FieldDeserializer(
 
 		//field is mandatory but it is not present in the input
 		if (data == null && isMandatory) {
-			throw Logger.handleException(
-				exceptionType = "MissingInput",
-				fieldPath = listOf(parentField, key),
-				className = className
-			)
+			throw  OpenID4VPExceptions.MissingInput("listOf(parentField, key)","",className)
 		} else if (data == JsonNull) {
-			throw Logger.handleException(
-				exceptionType = "InvalidInput",
-				fieldPath = listOf(parentField, key),
-				className = className,
-				fieldType = fieldType
-			)
+			throw OpenID4VPExceptions.InvalidInput(listOf(parentField, key),fieldType,className)
+
 		}
 		//field is mandatory or optional and it is present in the input
 		if (data != null) {
@@ -75,12 +68,7 @@ class FieldDeserializer(
 				else -> throw SerializationException("Unsupported field type: $fieldType")
 			}
 			require(validateField(res, fieldType)) {
-				throw Logger.handleException(
-					exceptionType = "InvalidInput",
-					fieldPath = listOf(parentField, key),
-					className = className,
-					fieldType = fieldType
-				)
+				throw OpenID4VPExceptions.InvalidInput(listOf(parentField, key),fieldType,className)
 			}
 			return res
 		} else {
@@ -111,12 +99,7 @@ class FieldDeserializer(
 				else -> true
 			}
 		) {
-			throw Logger.handleException(
-				exceptionType = "InvalidInput",
-				fieldPath = listOf(parentField, key),
-				className = className,
-				fieldType = fieldType
-			)
+			throw  OpenID4VPExceptions.InvalidInput(listOf(parentField, key),fieldType,className)
 		}
 	}
 }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/Utils.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/Utils.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mosip.openID4VP.constants.HttpMethod
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import java.security.SecureRandom
 
 private const val URL_PATTERN = "^https://(?:[\\w-]+\\.)+[\\w-]+(?:/[\\w\\-.~!$&'()*+,;=:@%]+)*/?(?:\\?[^#\\s]*)?(?:#.*)?$"
@@ -53,12 +54,11 @@ fun validate(
     className: String
 ) {
     if (value == null || value == "null" || value.isEmpty()) {
-        throw Logger.handleException(
-            exceptionType = if (value == null) "MissingInput" else "InvalidInput",
-            fieldPath = listOf(key),
-            className = className,
-            fieldType = "String"
-        )
+        throw if(value == null) {
+            OpenID4VPExceptions.MissingInput(listOf(key),"",className)
+        } else {
+            OpenID4VPExceptions.InvalidInput(listOf(key), "String", className)
+        }
     }
 }
 
@@ -67,12 +67,7 @@ inline fun <reified T> encodeToJsonString(data: T, fieldName: String, className:
         val objectMapper = jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
         return objectMapper.writeValueAsString(data)
     } catch (exception: Exception) {
-        throw Logger.handleException(
-            exceptionType = "JsonEncodingFailed",
-            message = exception.message,
-            fieldPath = listOf(fieldName),
-            className = className
-        )
+        throw  OpenID4VPExceptions.JsonEncodingFailed(listOf(fieldName), exception.message.toString(),className)
     }
 }
 

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/openId4VPErrorCodes.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/common/openId4VPErrorCodes.kt
@@ -1,0 +1,12 @@
+package io.mosip.openID4VP.common
+
+object OpenID4VPErrorCodes {
+    const val INVALID_REQUEST = "invalid_request"
+    const val INVALID_CLIENT = "invalid_client"
+    const val INVALID_SCOPE = "invalid_scope"
+    const val INVALID_PRESENTATION_DEFINITION_URI = "invalid_presentation_definition_uri"
+    const val VP_FORMATS_NOT_SUPPORTED = "vp_formats_not_supported"
+    const val INVALID_PRESENTATION_DEFINITION_REFERENCE = "invalid_presentation_definition_reference"
+    const val INVALID_REQUEST_URI_METHOD = "invalid_request_uri_method"
+    const val INVALID_TRANSACTION_DATA = "invalid_transaction_data"
+}

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/exceptions/Exceptions.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/exceptions/Exceptions.kt
@@ -11,7 +11,7 @@ sealed class Exceptions {
         }
     )
 
-    class InvalidInput(fieldPath: String, fieldType: Any?) :
+    class InvalidInput(fieldPath: Any, fieldType: Any?) :
         Exception(
             "Invalid Input: ${
                 when (fieldType) {

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/exceptions/openId4VPExceptions.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/exceptions/openId4VPExceptions.kt
@@ -1,0 +1,112 @@
+package io.mosip.openID4VP.exceptions
+
+import io.mosip.openID4VP.common.OpenID4VPErrorCodes
+
+sealed class OpenID4VPExceptions(
+    val errorCode: String,
+    override val message: String,
+    val className: String
+) : Exception("$errorCode : $message") {
+
+    init {
+        // Replace with Log.e if on Android
+        println("ERROR [$errorCode] - $message | Class: $className")
+    }
+
+    fun toErrorResponse(): Map<String, String> {
+        return mapOf(
+            "error" to errorCode,
+            "error_description" to message
+        )
+    }
+
+    // Authorization Exceptions
+
+    class InvalidVerifier(message: String, className: String) :
+        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, message, className)
+
+    class InvalidInputPattern(fieldPath: Any, className: String) :
+        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, "Invalid Input Pattern: $fieldPath pattern is not matching with OpenID4VP specification", className)
+
+    class JsonEncodingFailed(fieldPath: Any, errorMessage: String, className: String) :
+        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, "Json encoding failed for $fieldPath due to this error: $errorMessage", className)
+
+    class DeserializationFailure(fieldPath: Any, errorMessage: String, className: String) :
+        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, "Deserializing for $fieldPath failed due to this error: $errorMessage", className)
+
+    class InvalidLimitDisclosure(className: String) :
+        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, "Invalid Input: constraints->limit_disclosure value should be preferred", className)
+
+    class InvalidQueryParams(message: String, className: String) :
+        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, message, className)
+
+
+    // General Exceptions
+    class InvalidData(
+        message: String,
+        className: String,
+        code: String? = null
+    ) : OpenID4VPExceptions(
+        errorCode = code ?: OpenID4VPErrorCodes.INVALID_REQUEST,
+        message = message,
+        className = className
+    )
+
+
+    class MissingInput(fieldPath: Any, message: String, className: String) :
+        OpenID4VPExceptions(
+            OpenID4VPErrorCodes.INVALID_REQUEST,
+            when {
+                fieldPath is String && fieldPath.isNotEmpty() -> "Missing Input: $fieldPath param is required"
+                fieldPath is List<*> && fieldPath.isNotEmpty() -> "Missing Input: ${fieldPath.joinToString(".")} param is required"
+                else -> message
+            },
+            className
+        )
+
+    class InvalidInput(fieldPath: Any, fieldType: Any?, className: String) :
+        OpenID4VPExceptions(
+            OpenID4VPErrorCodes.INVALID_REQUEST,
+            "Invalid Input: ${
+                when (fieldType) {
+                    "String" -> "$fieldPath value cannot be an empty string, null, or an integer"
+                    "Boolean" -> "$fieldPath value must be either true or false"
+                    else -> "$fieldPath value cannot be empty or null"
+                }
+            }",
+            className
+        )
+
+
+    // JWS Exceptions
+
+    class PublicKeyExtractionFailed(message: String, className: String) :
+        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, message, className)
+
+    class KidExtractionFailed(message: String, className: String) :
+        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, message, className)
+
+    class PublicKeyResolutionFailed(message: String, className: String) :
+        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, message, className)
+
+    class InvalidSignature(message: String, className: String) :
+        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, message, className)
+
+    class VerificationFailure(message: String, className: String) :
+        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, message, className)
+
+    // JWE Exceptions
+
+    class UnsupportedKeyExchangeAlgorithm(className: String) :
+        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, "Required Key exchange algorithm is not supported", className)
+
+    class JweEncryptionFailure(className: String) :
+        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, "JWE Encryption failed", className)
+
+
+    //fallback
+    class GeneralFailure(
+        override val message: String,
+        className: String,
+    ) : OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, message, className)
+}

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/jwt/jwe/JWEHandler.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/jwt/jwe/JWEHandler.kt
@@ -6,6 +6,7 @@ import com.nimbusds.jwt.JWTClaimsSet
 import io.mosip.openID4VP.authorizationRequest.clientMetadata.Jwk
 import io.mosip.openID4VP.jwt.jwe.encryption.EncryptionProvider
 import io.mosip.openID4VP.common.Logger
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 
 private val className = JWEHandler::class.simpleName!!
 
@@ -39,11 +40,7 @@ class JWEHandler(
             jwt.encrypt(encrypter)
             return jwt.serialize()
         } catch (exception: Exception) {
-            throw Logger.handleException(
-                exceptionType = "JweEncryptionFailure",
-                message = exception.message,
-                className = className
-            )
+            throw  OpenID4VPExceptions.JweEncryptionFailure(className)
         }
     }
 }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/jwt/jwe/encryption/EncryptionProvider.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/jwt/jwe/encryption/EncryptionProvider.kt
@@ -11,6 +11,7 @@ import com.nimbusds.jose.jwk.OctetKeyPair
 import com.nimbusds.jose.util.Base64URL
 import io.mosip.openID4VP.authorizationRequest.clientMetadata.Jwk
 import io.mosip.openID4VP.common.Logger
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 
 private val className = EncryptionProvider::class.simpleName!!
 object EncryptionProvider {
@@ -18,10 +19,7 @@ object EncryptionProvider {
     fun getEncrypter(jwk: Jwk): JWEEncrypter =
         when (jwk.kty) {
             KeyType.OKP.value -> X25519Encrypter(getPublicOctetKey(jwk))
-            else -> throw Logger.handleException(
-                exceptionType = "UnsupportedKeyExchangeAlgorithm",
-                className = className
-            )
+            else -> throw OpenID4VPExceptions.UnsupportedKeyExchangeAlgorithm(className)
         }
 
     private fun getPublicOctetKey(jwk: Jwk): OctetKeyPair {

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/jwt/jws/JWSHandler.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/jwt/jws/JWSHandler.kt
@@ -3,6 +3,7 @@ package io.mosip.openID4VP.jwt.jws
 import io.mosip.openID4VP.common.Decoder.decodeBase64Data
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.common.convertJsonToMap
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.jwt.jws.JWSHandler.JwsPart.*
 import io.mosip.openID4VP.jwt.keyResolver.PublicKeyResolver
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
@@ -38,19 +39,11 @@ class JWSHandler(private val jws: String, private val publicKeyResolver: PublicK
             verificationResult = signer.verifySignature(signature)
 
         } catch (ex: Exception) {
-            throw Logger.handleException(
-                exceptionType = "VerificationFailure",
-                className = className,
-                message = "An unexpected exception occurred during verification: ${ex.message}",
-
-            )
+            throw  OpenID4VPExceptions.VerificationFailure("An unexpected exception occurred during verification: ${ex.message}", className)
         }
         if (!verificationResult)
-            throw Logger.handleException(
-                exceptionType = "InvalidSignature",
-                className = className,
-                message = "JWS signature verification failed"
-            )
+            throw  OpenID4VPExceptions.VerificationFailure("WS signature verification failed",
+                className)
     }
 
     fun extractDataJsonFromJws(part: JwsPart): MutableMap<String, Any> {

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/jwt/keyResolver/types/DidPublicKeyResolver.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/jwt/keyResolver/types/DidPublicKeyResolver.kt
@@ -1,6 +1,7 @@
 package io.mosip.openID4VP.jwt.keyResolver.types
 
 import io.mosip.openID4VP.common.Logger
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.jwt.keyResolver.PublicKeyResolver
 import io.mosip.vercred.vcverifier.DidWebResolver
 
@@ -13,25 +14,15 @@ class DidPublicKeyResolver(private val didUrl: String) : PublicKeyResolver {
         val didResponse = try {
             DidWebResolver(didUrl).resolve()
         }catch (e: Exception){
-            throw Logger.handleException(
-                exceptionType = "PublicKeyResolutionFailed",
-                className = className,
-                message = e.message
-            )
+            throw OpenID4VPExceptions.PublicKeyResolutionFailed(e.message.toString(), className)
         }
 
         val kid = header["kid"]?.toString()
-            ?: throw Logger.handleException(
-                exceptionType = "KidExtractionFailed",
-                className = className,
-                message = "KID extraction from DID document failed"
-            )
+            ?: throw OpenID4VPExceptions.KidExtractionFailed("KID extraction from DID document failed",
+                className)
+
         return extractPublicKeyMultibase(kid, didResponse)
-            ?: throw Logger.handleException(
-                exceptionType = "PublicKeyExtractionFailed",
-                className = className,
-                message = "Public key extraction failed"
-            )
+            ?: throw  OpenID4VPExceptions.PublicKeyExtractionFailed("Public key extraction failed", className)
     }
 
     private fun extractPublicKeyMultibase(kid: String, didDocument: Map<String, Any>): String? {

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/responseModeHandler/ResponseModeBasedHandler.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/responseModeHandler/ResponseModeBasedHandler.kt
@@ -9,6 +9,7 @@ import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.common.getStringValue
 import io.mosip.openID4VP.common.isValidUrl
 import io.mosip.openID4VP.common.validate
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 
 private val className = ResponseModeBasedHandler::class.simpleName!!
 
@@ -36,11 +37,7 @@ abstract class ResponseModeBasedHandler {
         val responseUri = getStringValue(authorizationRequestParameters, RESPONSE_URI.value)
         validate(RESPONSE_URI.value, responseUri, className)
         if (!isValidUrl(responseUri!!)) {
-            throw Logger.handleException(
-                exceptionType = "InvalidData",
-                className = className,
-                message = "${RESPONSE_URI.value} data is not valid"
-            )
+            throw OpenID4VPExceptions.InvalidData("${RESPONSE_URI.value} data is not valid", className)
         }
         setResponseUri(responseUri)
     }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/responseModeHandler/ResponseModeBasedHandlerFactory.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/responseModeHandler/ResponseModeBasedHandlerFactory.kt
@@ -2,6 +2,7 @@ package io.mosip.openID4VP.responseModeHandler
 
 import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.constants.ResponseMode.*
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.responseModeHandler.types.DirectPostJwtResponseModeHandler
 import io.mosip.openID4VP.responseModeHandler.types.DirectPostResponseModeHandler
 
@@ -13,10 +14,6 @@ object ResponseModeBasedHandlerFactory {
             DIRECT_POST.value -> DirectPostResponseModeHandler()
             DIRECT_POST_JWT.value -> DirectPostJwtResponseModeHandler()
             else ->
-                throw Logger.handleException(
-                    exceptionType = "InvalidData",
-                    className = className,
-                    message = "Given response_mode is not supported"
-                )
+                throw  OpenID4VPExceptions.InvalidData("Given response_mode is not supported", className)
         }
 }

--- a/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/responseModeHandler/types/DirectPostJwtResponseModeHandler.kt
+++ b/kotlin/openID4VP/src/main/java/io/mosip/openID4VP/responseModeHandler/types/DirectPostJwtResponseModeHandler.kt
@@ -9,6 +9,7 @@ import io.mosip.openID4VP.common.Logger
 import io.mosip.openID4VP.jwt.jwe.JWEHandler
 import io.mosip.openID4VP.constants.ContentType
 import io.mosip.openID4VP.constants.HttpMethod
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandler
 
@@ -71,19 +72,11 @@ class DirectPostJwtResponseModeHandler : ResponseModeBasedHandler() {
     }
 
     private fun throwMissingInputException(fieldName: String): Nothing {
-        throw Logger.handleException(
-            exceptionType = "MissingInput",
-            className = className,
-            fieldPath = listOf("client_metadata", fieldName)
-        )
+        throw  OpenID4VPExceptions.MissingInput(listOf("client_metadata", fieldName), "",className)
     }
 
     private fun throwInvalidDataException(message: String): Nothing {
-        throw Logger.handleException(
-            exceptionType = "InvalidData",
-            className = className,
-            message = message
-        )
+        throw  OpenID4VPExceptions.InvalidData(message, className)
     }
 
     override fun sendAuthorizationResponse(

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/WalletMetadataTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/WalletMetadataTest.kt
@@ -5,7 +5,7 @@ import io.mockk.every
 import io.mockk.mockkStatic
 import io.mosip.openID4VP.constants.ClientIdScheme
 import io.mosip.openID4VP.constants.ClientIdScheme.PRE_REGISTERED
-import io.mosip.openID4VP.exceptions.Exceptions.InvalidData
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import org.junit.Before
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.*
@@ -46,7 +46,7 @@ class WalletMetadataTest {
             authorizationEncryptionAlgValuesSupported = listOf("ECDH-ES"),
             authorizationEncryptionEncValuesSupported = listOf("A256GCM")
         )
-        assertEquals(walletMetadata.presentationDefinitionURISupported, true)
+        assertEquals(true, walletMetadata.presentationDefinitionURISupported)
     }
 
     @Test
@@ -63,11 +63,11 @@ class WalletMetadataTest {
             authorizationEncryptionAlgValuesSupported = listOf("ECDH-ES"),
             authorizationEncryptionEncValuesSupported = listOf("A256GCM")
         )
-        assertEquals(walletMetadata.clientIdSchemesSupported, listOf(PRE_REGISTERED.value))
+        assertEquals(listOf(PRE_REGISTERED.value), walletMetadata.clientIdSchemesSupported)
     }
 
     @Test
-    fun `should keep null value for authorization_encryption_enc_values_supported and authorization_encryption_alg_values_supported if provided` () {
+    fun `should keep null value for authorization_encryption_enc_values_supported and authorization_encryption_alg_values_supported if provided`() {
         val walletMetadata = WalletMetadata(
             presentationDefinitionURISupported = true,
             vpFormatsSupported = mapOf(
@@ -80,12 +80,12 @@ class WalletMetadataTest {
             authorizationEncryptionAlgValuesSupported = null,
             authorizationEncryptionEncValuesSupported = null
         )
-        assertEquals(walletMetadata.clientIdSchemesSupported, listOf(PRE_REGISTERED.value))
+        assertEquals(listOf(PRE_REGISTERED.value), walletMetadata.clientIdSchemesSupported)
     }
 
     @Test
     fun `should throw error if vp_formats_supported is empty map`() {
-        val exception = assertThrows<InvalidData> {
+        val exception = assertThrows<OpenID4VPExceptions.InvalidData> {
             WalletMetadata(
                 presentationDefinitionURISupported = true,
                 vpFormatsSupported = emptyMap(),
@@ -103,9 +103,10 @@ class WalletMetadataTest {
             exception.message
         )
     }
+
     @Test
     fun `should throw error if vp_formats_supported has empty key`() {
-        val exception = assertThrows<InvalidData> {
+        val exception = assertThrows<OpenID4VPExceptions.InvalidData> {
             WalletMetadata(
                 presentationDefinitionURISupported = true,
                 vpFormatsSupported = mapOf(
@@ -127,13 +128,14 @@ class WalletMetadataTest {
             exception.message
         )
     }
+
     @Test
     fun `should throw error if vp_formats_supported has just empty space`() {
-        val exception = assertThrows<InvalidData> {
+        val exception = assertThrows<OpenID4VPExceptions.InvalidData> {
             WalletMetadata(
                 presentationDefinitionURISupported = true,
                 vpFormatsSupported = mapOf(
-                    " "  to VPFormatSupported(
+                    " " to VPFormatSupported(
                         algValuesSupported = null
                     )
                 ),

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/ConstraintsTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/ConstraintsTest.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockkStatic
 import io.mosip.openID4VP.authorizationRequest.deserializeAndValidate
 import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -34,15 +35,14 @@ class ConstraintsTest {
 		val presentationDefinition =
 			"""{"id":"pd_123","input_descriptors":[{"id":"id_123","format":{"ldp_vc":{"proof_type":["RsaSignature2018"]}},"constraints":{"fields":[{"path":["$.type"]}],"limit_disclosure": "not preferred"}}]}"""
 
-		val expectedExceptionMessage =
-			"Invalid Input: constraints->limit_disclosure value should be preferred"
-
 		val actualException =
-			Assert.assertThrows(AuthorizationRequestExceptions.InvalidLimitDisclosure::class.java) {
+			Assert.assertThrows(OpenID4VPExceptions.InvalidLimitDisclosure::class.java) {
 				deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
 			}
 
-		Assert.assertEquals(expectedExceptionMessage, actualException.message)
+		val expectedExceptionMessage =
+			"Invalid Input: constraints->limit_disclosure value should be preferred"
 
+		Assert.assertEquals(expectedExceptionMessage, actualException.message)
 	}
 }

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FieldsTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FieldsTest.kt
@@ -8,6 +8,7 @@ import io.mosip.openID4VP.authorizationRequest.deserializeAndValidate
 import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions.InvalidInputPattern
 import io.mosip.openID4VP.exceptions.Exceptions
 import io.mosip.openID4VP.exceptions.Exceptions.MissingInput
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 
 import org.junit.After
 import org.junit.Assert
@@ -42,7 +43,7 @@ class FieldsTest {
 			"Invalid Input Pattern: fields->path pattern is not matching with OpenId4VP specification"
 
 		val actualException =
-			Assert.assertThrows(InvalidInputPattern::class.java) {
+			Assert.assertThrows(OpenID4VPExceptions.InvalidInputPattern::class.java) {
 				deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
 			}
 
@@ -56,7 +57,7 @@ class FieldsTest {
 		expectedExceptionMessage = "Missing Input: fields->path param is required"
 
 		val actualException =
-			Assert.assertThrows(MissingInput::class.java) {
+			Assert.assertThrows(OpenID4VPExceptions.MissingInput::class.java) {
 				deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
 			}
 
@@ -70,7 +71,7 @@ class FieldsTest {
 		expectedExceptionMessage = "Invalid Input: fields->path value cannot be empty or null"
 
 		val actualException =
-			Assert.assertThrows(Exceptions.InvalidInput::class.java) {
+			Assert.assertThrows(OpenID4VPExceptions.InvalidInput::class.java) {
 				deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
 			}
 
@@ -84,7 +85,7 @@ class FieldsTest {
 		expectedExceptionMessage = "Invalid Input: fields->path value cannot be empty or null"
 
 		val actualException =
-			Assert.assertThrows(Exceptions.InvalidInput::class.java) {
+			Assert.assertThrows(OpenID4VPExceptions.InvalidInput::class.java) {
 				deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
 			}
 

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FilterTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/FilterTest.kt
@@ -5,10 +5,7 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mosip.openID4VP.authorizationRequest.deserializeAndValidate
-import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
-import io.mosip.openID4VP.exceptions.Exceptions
-import io.mosip.openID4VP.exceptions.Exceptions.MissingInput
-
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -41,7 +38,7 @@ class FilterTest {
 		expectedExceptionMessage = "Missing Input: filter->type param is required"
 
 		val actualException =
-			Assert.assertThrows(MissingInput::class.java) {
+			Assert.assertThrows(OpenID4VPExceptions.MissingInput::class.java) {
 				deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
 			}
 
@@ -55,7 +52,7 @@ class FilterTest {
 		expectedExceptionMessage = "Missing Input: filter->pattern param is required"
 
 		val actualException =
-			Assert.assertThrows(MissingInput::class.java) {
+			Assert.assertThrows(OpenID4VPExceptions.MissingInput::class.java) {
 				deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
 			}
 
@@ -69,7 +66,7 @@ class FilterTest {
 		expectedExceptionMessage = "Invalid Input: filter->type value cannot be an empty string, null, or an integer"
 
 		val actualException =
-			Assert.assertThrows(Exceptions.InvalidInput::class.java) {
+			Assert.assertThrows(OpenID4VPExceptions.InvalidInput::class.java) {
 				deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
 			}
 
@@ -83,7 +80,7 @@ class FilterTest {
 		expectedExceptionMessage = "Invalid Input: filter->pattern value cannot be an empty string, null, or an integer"
 
 		val actualException =
-			Assert.assertThrows(Exceptions.InvalidInput::class.java) {
+			Assert.assertThrows(OpenID4VPExceptions.InvalidInput::class.java) {
 				deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
 			}
 
@@ -97,7 +94,7 @@ class FilterTest {
 		expectedExceptionMessage = "Invalid Input: filter->pattern value cannot be an empty string, null, or an integer"
 
 		val actualException =
-			Assert.assertThrows(Exceptions.InvalidInput::class.java) {
+			Assert.assertThrows(OpenID4VPExceptions.InvalidInput::class.java) {
 				deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
 			}
 

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptorTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/InputDescriptorTest.kt
@@ -5,9 +5,7 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mosip.openID4VP.authorizationRequest.deserializeAndValidate
-import io.mosip.openID4VP.authorizationRequest.exception.AuthorizationRequestExceptions
-import io.mosip.openID4VP.exceptions.Exceptions
-import io.mosip.openID4VP.exceptions.Exceptions.MissingInput
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -40,7 +38,7 @@ class InputDescriptorTest {
         expectedExceptionMessage = "Missing Input: input_descriptor->id param is required"
 
         val actualException =
-            Assert.assertThrows(MissingInput::class.java) {
+            Assert.assertThrows(OpenID4VPExceptions.MissingInput::class.java) {
                 deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
             }
 
@@ -54,7 +52,7 @@ class InputDescriptorTest {
         expectedExceptionMessage = "Missing Input: input_descriptor->constraints param is required"
 
         val actualException =
-            Assert.assertThrows(MissingInput::class.java) {
+            Assert.assertThrows(OpenID4VPExceptions.MissingInput::class.java) {
                 deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
             }
 
@@ -68,7 +66,7 @@ class InputDescriptorTest {
         expectedExceptionMessage = "Invalid Input: input_descriptor->id value cannot be an empty string, null, or an integer"
 
         val actualException =
-            Assert.assertThrows(Exceptions.InvalidInput::class.java) {
+            Assert.assertThrows(OpenID4VPExceptions.InvalidInput::class.java) {
                 deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
             }
 
@@ -82,7 +80,7 @@ class InputDescriptorTest {
         expectedExceptionMessage = "Invalid Input: input_descriptor->id value cannot be an empty string, null, or an integer"
 
         val actualException =
-            Assert.assertThrows(Exceptions.InvalidInput::class.java) {
+            Assert.assertThrows(OpenID4VPExceptions.InvalidInput::class.java) {
                 deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
             }
 

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionTest.kt
@@ -8,9 +8,7 @@ import io.mosip.openID4VP.authorizationRequest.AuthorizationRequestFieldConstant
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequestFieldConstants.RESPONSE_MODE
 import io.mosip.openID4VP.authorizationRequest.deserializeAndValidate
 import io.mosip.openID4VP.constants.ResponseMode.DIRECT_POST_JWT
-import io.mosip.openID4VP.exceptions.Exceptions.InvalidData
-import io.mosip.openID4VP.exceptions.Exceptions.InvalidInput
-import io.mosip.openID4VP.exceptions.Exceptions.MissingInput
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -50,7 +48,7 @@ class PresentationDefinitionTest {
         expectedExceptionMessage = "Missing Input: presentation_definition->id param is required"
 
         val actualException =
-            assertThrows(MissingInput::class.java) {
+            assertThrows(OpenID4VPExceptions.MissingInput::class.java) {
                 deserializeAndValidate(
                     presentationDefinition,
                     PresentationDefinitionSerializer
@@ -67,7 +65,7 @@ class PresentationDefinitionTest {
             "Missing Input: presentation_definition->input_descriptors param is required"
 
         val actualException =
-            assertThrows(MissingInput::class.java) {
+            assertThrows(OpenID4VPExceptions.MissingInput::class.java) {
                 deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
             }
 
@@ -82,7 +80,7 @@ class PresentationDefinitionTest {
             "Invalid Input: presentation_definition->id value cannot be an empty string, null, or an integer"
 
         val actualException =
-            assertThrows(InvalidInput::class.java) {
+            assertThrows(OpenID4VPExceptions.InvalidInput::class.java) {
                 deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
             }
 
@@ -96,7 +94,7 @@ class PresentationDefinitionTest {
             "Invalid Input: presentation_definition->input_descriptors value cannot be empty or null"
 
         val actualException =
-            assertThrows(InvalidInput::class.java) {
+            assertThrows(OpenID4VPExceptions.InvalidInput::class.java) {
                 deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
             }
 
@@ -110,7 +108,7 @@ class PresentationDefinitionTest {
             "Invalid Input: presentation_definition->input_descriptors value cannot be empty or null"
 
         val actualException =
-            assertThrows(InvalidInput::class.java) {
+            assertThrows(OpenID4VPExceptions.InvalidInput::class.java) {
                 deserializeAndValidate(presentationDefinition, PresentationDefinitionSerializer)
             }
 
@@ -127,12 +125,11 @@ class PresentationDefinitionTest {
         val expectedExceptionMessage =
             "presentation_definition_uri is not support"
 
-        val exception = assertThrows<InvalidData> {
+        val exception = assertThrows(OpenID4VPExceptions.InvalidData::class.java) {
             parseAndValidatePresentationDefinition(authorizationRequestParam, false)
         }
 
-        Assertions.assertEquals(expectedExceptionMessage, exception.message)
-
+        assertEquals(expectedExceptionMessage, exception.message)
     }
 
     @Test

--- a/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationResponse/unsignedVPToken/types/mdoc/UnsignedMdocVPTokenBuilderTest.kt
+++ b/kotlin/openID4VP/src/test/java/io/mosip/openID4VP/authorizationResponse/unsignedVPToken/types/mdoc/UnsignedMdocVPTokenBuilderTest.kt
@@ -5,6 +5,7 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mosip.openID4VP.exceptions.Exceptions.InvalidData
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.testData.mdocCredential
 import io.mosip.openID4VP.testData.responseUrl
 import org.junit.After
@@ -68,7 +69,7 @@ class UnsignedMdocVPTokenBuilderTest {
         val mdocCredentials = listOf(mdocCredential, mdocCredential)
 
         val actualException =
-            assertThrows(InvalidData::class.java) {
+            assertThrows(OpenID4VPExceptions.InvalidData::class.java) {
                 UnsignedMdocVPTokenBuilder(
                     mdocCredentials,
                     clientId,


### PR DESCRIPTION
The New error handling approach is implemented here along with the error codes 

Current Implementation: The Logger class grows with each new exception, and throwing exceptions requires hardcoded string types that are hard to maintain.
Proposed Solution: Replace Logger.handleException() with a sealed class hierarchy where OpenID4VPExceptions serves as the base template that automatically handles logging in its init block and the exceptions as well