### PR TITLE
[INJIMOB-3414]: [Develop]Align with swift feedbacks

### DIFF
--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -355,13 +355,16 @@ val authorizationRequest: AuthorizationRequest = openID4VP.authenticateVerifier(
     - For `direct_post.jwt` response mode
         - client_metadata is not available
         - unable to find the public key JWK from the `jwks` of `client_metadata` as per the provided algorithm in `client_metadata`
+   - `publicKeyMultibase` is null or empty
+8. UnsupportedPublicKeyType exception is thrown when the public key type is not `publicKeyMultibase`.
+9. PublicKeyExtractionFailed exception is thrown when there are any errors in extracting the public key from verification method
 
 This method will also notify the Verifier about the error by sending it to the response_uri endpoint over http post request. If response_uri is invalid and validation failed then Verifier won't be able to know about it.
 
 
 ##### Exception Handling Enhancement
 
-- The library has been enhanced to handle exceptions more gracefully. Library is throwing `OpenID4VPExceptions` now which gives both Error Code and Message to the consumer app. This allows the consumer app to handle exceptions more effectively and provide better user experience.
+- The library has been enhanced to handle exceptions more gracefully. Library is throwing `OpenID4VPExceptions` now which gives both Error Code, Message and optional state to the consumer app. The `state` value is extracted from the authorization request and is included in the error response only if it is present and non-empty. This allows the consumer app to handle exceptions more effectively and provide better user experience.
 - For the backward compatibility, the library will still throw the exceptions with `message` which can be referred in sample application `io.mosip.sampleapp.utils.OpenID4VPManager`. However, it is recommended to use the new `OpenID4VPExceptions` for better error handling.
 
 

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/exceptions/openId4VPExceptions.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/exceptions/openId4VPExceptions.kt
@@ -102,7 +102,7 @@ sealed class OpenID4VPExceptions(
         OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, message, className)
 
     class UnsupportedPublicKeyType(className: String) :
-        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, "Unsupported Public Key type. Must be 'publicKeyMultibase'", className)
+        OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, "Unsupported Public Key type. Supported: publicKeyMultibase", className)
 
     class KidExtractionFailed(message: String, className: String) :
         OpenID4VPExceptions(OpenID4VPErrorCodes.INVALID_REQUEST, message, className)

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/jwt/keyResolver/DidPublicKeyResolverTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/jwt/keyResolver/DidPublicKeyResolverTest.kt
@@ -85,6 +85,52 @@ class DidPublicKeyResolverTest {
     }
 
     @Test
+    fun `should throw exception when publicKeyMultibase is empty  verificationMethod`() {
+        val mockResponse = mapOf(
+            "verificationMethod" to listOf(
+                mapOf("publicKeyMultibase" to  "",
+                    "controller" to "did:web:mosip.github.io:inji-mock-services:openid4vp-service:docs",
+                    "id" to "did:web:mosip.github.io:inji-mock-services:openid4vp-service:docs#key-0",
+                    "type" to "Ed25519VerificationKey2020",
+                    "@context" to "https://w3id.org/security/suites/ed25519-2020/v1"
+                )
+            )
+        )
+
+        every { anyConstructed<DidWebResolver>().resolve() } returns mockResponse
+
+        val header = mapOf("kid" to "did:web:mosip.github.io:inji-mock-services:openid4vp-service:docs#key-0")
+
+        val exception = assertFailsWith<InvalidData> {
+            resolver.resolveKey(header)
+        }
+        assertEquals("publicKeyMultibase cannot be null or empty", exception.message)
+    }
+
+    @Test
+    fun `should throw exception when publicKeyMultibase is null  verificationMethod`() {
+        val mockResponse = mapOf(
+            "verificationMethod" to listOf(
+                mapOf("publicKeyMultibase" to  null,
+                    "controller" to "did:web:mosip.github.io:inji-mock-services:openid4vp-service:docs",
+                    "id" to "did:web:mosip.github.io:inji-mock-services:openid4vp-service:docs#key-0",
+                    "type" to "Ed25519VerificationKey2020",
+                    "@context" to "https://w3id.org/security/suites/ed25519-2020/v1"
+                )
+            )
+        )
+
+        every { anyConstructed<DidWebResolver>().resolve() } returns mockResponse
+
+        val header = mapOf("kid" to "did:web:mosip.github.io:inji-mock-services:openid4vp-service:docs#key-0")
+
+        val exception = assertFailsWith<InvalidData> {
+            resolver.resolveKey(header)
+        }
+        assertEquals("publicKeyMultibase cannot be null or empty", exception.message)
+    }
+
+    @Test
     fun `should throw exception when unsupported public key- publicKeyHex present in verificationMethod`() {
         val mockResponse = mapOf(
             "verificationMethod" to listOf(
@@ -104,7 +150,7 @@ class DidPublicKeyResolverTest {
         val exception = assertFailsWith<UnsupportedPublicKeyType> {
             resolver.resolveKey(header)
         }
-        assertEquals("Unsupported Public Key type. Must be 'publicKeyMultibase'", exception.message)
+        assertEquals("Unsupported Public Key type. Supported: publicKeyMultibase", exception.message)
     }
 
     @Test
@@ -127,7 +173,7 @@ class DidPublicKeyResolverTest {
         val exception = assertFailsWith<UnsupportedPublicKeyType> {
             resolver.resolveKey(header)
         }
-        assertEquals("Unsupported Public Key type. Must be 'publicKeyMultibase'", exception.message)
+        assertEquals("Unsupported Public Key type. Supported: publicKeyMultibase", exception.message)
     }
 
     @Test
@@ -150,6 +196,6 @@ class DidPublicKeyResolverTest {
         val exception = assertFailsWith<UnsupportedPublicKeyType> {
             resolver.resolveKey(header)
         }
-        assertEquals("Unsupported Public Key type. Must be 'publicKeyMultibase'", exception.message)
+        assertEquals("Unsupported Public Key type. Supported: publicKeyMultibase", exception.message)
     }
 }

--- a/kotlin/openID4VP/src/jvmTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthRequestByReferenceTest.kt
+++ b/kotlin/openID4VP/src/jvmTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthRequestByReferenceTest.kt
@@ -1,6 +1,7 @@
 package io.mosip.openID4VP.authorizationRequest
 
 import io.mockk.every
+import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.verify
 import io.mosip.openID4VP.OpenID4VP
@@ -29,6 +30,7 @@ import io.mosip.openID4VP.testData.requestParams
 import io.mosip.openID4VP.testData.requestUrl
 import io.mosip.openID4VP.testData.trustedVerifiers
 import io.mosip.openID4VP.testData.walletMetadata
+import io.mosip.vercred.vcverifier.DidWebResolver
 import okhttp3.Headers
 import kotlin.test.*
 
@@ -53,6 +55,21 @@ class AuthRequestByReferenceTest {
                 HttpMethod.GET
             )
         } returns mapOf("body" to didResponse)
+
+        mockkConstructor(DidWebResolver::class)
+
+        every {
+            anyConstructed<DidWebResolver>().resolve()
+        } returns mapOf(
+            "verificationMethod" to listOf(
+                mapOf(
+                    "id" to "did:web:mosip.github.io:inji-mock-services:openid4vp-service:docs#key-0",
+                    "type" to "Ed25519VerificationKey2020",
+                    "controller" to "did:web:mosip.github.io",
+                    "publicKeyMultibase" to "z3CSkXmF1DmgVuqPFKMTuJgn846mEuVB9rNoyP9hXribo"
+                )
+            )
+        )
 
 
     }


### PR DESCRIPTION
- Updated error message for unsupported public key type
- Update AuthRequestbyReference Test to use mock DidWebResolver instead of real ones, becuase after the did.json revert , tests started failing
- Updated tests for Publick key empty scenario and state field