### PR TITLE
[INJIMOB-3550] add: sendAuthorizationResponseToVerifier method

### DIFF
--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
@@ -9,6 +9,7 @@ import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.V
 import io.mosip.openID4VP.constants.*
 import io.mosip.openID4VP.common.*
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
+import io.mosip.openID4VP.networkManager.NetworkResponse
 
 class OpenID4VP @JvmOverloads constructor(
     private val traceabilityId: String,
@@ -70,6 +71,23 @@ class OpenID4VP @JvmOverloads constructor(
         }
     }
 
+    /** Sends the final Authorization response to Verifier with the Verifiable Presentations as per response type */
+    fun sendAuthorizationResponseToVerifier(
+        vpTokenSigningResults: Map<FormatType, VPTokenSigningResult>
+    ): NetworkResponse {
+        return try {
+            authorizationResponseHandler.shareVP(
+                authorizationRequest = authorizationRequest!!,
+                vpTokenSigningResults = vpTokenSigningResults,
+                responseUri = responseUri!!
+            )
+        } catch (exception: OpenID4VPExceptions) {
+            this.safeSendError(exception)
+            throw exception
+        }
+    }
+
+    @Deprecated("Use sendAuthorizationResponseToVerifier instead")
     /** Sends the final signed VP token response to the verifier */
     fun shareVerifiablePresentation(
         vpTokenSigningResults: Map<FormatType, VPTokenSigningResult>
@@ -79,7 +97,7 @@ class OpenID4VP @JvmOverloads constructor(
                 authorizationRequest = authorizationRequest!!,
                 vpTokenSigningResults = vpTokenSigningResults,
                 responseUri = responseUri!!
-            )
+            ).body
         } catch (exception: OpenID4VPExceptions) {
             this.safeSendError(exception)
             throw exception

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
@@ -26,6 +26,7 @@ import io.mosip.openID4VP.common.encodeToJsonString
 import io.mosip.openID4VP.constants.ContentType
 import io.mosip.openID4VP.constants.HttpMethod
 import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
+import io.mosip.openID4VP.networkManager.NetworkResponse
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandlerFactory
 
 private val className = AuthorizationResponseHandler::class.java.simpleName
@@ -145,7 +146,7 @@ internal class AuthorizationResponseHandler {
         authorizationRequest: AuthorizationRequest,
         vpTokenSigningResults: Map<FormatType, VPTokenSigningResult>,
         responseUri: String,
-    ): String {
+    ): NetworkResponse {
         val authorizationResponse: AuthorizationResponse = createAuthorizationResponse(
             authorizationRequest = authorizationRequest,
             vpTokenSigningResults = vpTokenSigningResults
@@ -191,7 +192,7 @@ internal class AuthorizationResponseHandler {
         authorizationResponse: AuthorizationResponse,
         responseUri: String,
         authorizationRequest: AuthorizationRequest,
-    ): String {
+    ): NetworkResponse {
         return ResponseModeBasedHandlerFactory.get(authorizationRequest.responseMode!!)
             .sendAuthorizationResponse(
                 authorizationRequest = authorizationRequest,
@@ -388,7 +389,7 @@ internal class AuthorizationResponseHandler {
                 authorizationResponse = authorizationResponse,
                 responseUri = responseUri,
                 authorizationRequest = authorizationRequest
-            )
+            ).body
         } catch (exception: Exception) {
             throw exception
         }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/ResponseModeBasedHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/ResponseModeBasedHandler.kt
@@ -9,6 +9,7 @@ import io.mosip.openID4VP.common.getStringValue
 import io.mosip.openID4VP.common.isValidUrl
 import io.mosip.openID4VP.common.validate
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
+import io.mosip.openID4VP.networkManager.NetworkResponse
 
 private val className = ResponseModeBasedHandler::class.simpleName!!
 
@@ -27,7 +28,7 @@ abstract class ResponseModeBasedHandler {
         url: String,
         authorizationResponse: AuthorizationResponse,
         walletNonce: String,
-    ): String
+    ): NetworkResponse
 
     fun setResponseUrl(
         authorizationRequestParameters: Map<String, Any>,

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostJwtResponseModeHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostJwtResponseModeHandler.kt
@@ -12,6 +12,7 @@ import io.mosip.openID4VP.constants.HttpMethod
 import io.mosip.openID4VP.constants.KeyManagementAlgorithm
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
+import io.mosip.openID4VP.networkManager.NetworkResponse
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandler
 
 private val className = DirectPostJwtResponseModeHandler::class.simpleName!!
@@ -85,7 +86,7 @@ class DirectPostJwtResponseModeHandler : ResponseModeBasedHandler() {
         url: String,
         authorizationResponse: AuthorizationResponse,
         walletNonce: String
-    ): String {
+    ): NetworkResponse {
         val bodyParams = authorizationResponse.toJsonEncodedMap()
         val clientMetadata = authorizationRequest.clientMetadata!!
 
@@ -102,14 +103,11 @@ class DirectPostJwtResponseModeHandler : ResponseModeBasedHandler() {
         val encryptedBody = jweHandler.generateEncryptedResponse(bodyParams)
         val encryptedBodyParams = mapOf("response" to encryptedBody)
 
-        val response = sendHTTPRequest(
+        return sendHTTPRequest(
             url = url,
             method = HttpMethod.POST,
             bodyParams = encryptedBodyParams,
             headers = mapOf("Content-Type" to ContentType.APPLICATION_FORM_URL_ENCODED.value)
         )
-        return response.body
     }
-
-
 }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostResponseModeHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostResponseModeHandler.kt
@@ -9,6 +9,7 @@ import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTP
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandler
 import io.mosip.openID4VP.constants.ContentType.APPLICATION_FORM_URL_ENCODED
 import io.mosip.openID4VP.constants.HttpMethod
+import io.mosip.openID4VP.networkManager.NetworkResponse
 
 class DirectPostResponseModeHandler: ResponseModeBasedHandler() {
     override fun validate(
@@ -24,7 +25,7 @@ class DirectPostResponseModeHandler: ResponseModeBasedHandler() {
         url: String,
         authorizationResponse: AuthorizationResponse,
         walletNonce: String
-    ): String {
+    ): NetworkResponse {
         val bodyParams: Map<String, String> = authorizationResponse.toJsonEncodedMap()
         val response = sendHTTPRequest(
             url = url,
@@ -32,6 +33,6 @@ class DirectPostResponseModeHandler: ResponseModeBasedHandler() {
             bodyParams = bodyParams,
             headers = mapOf("Content-Type" to APPLICATION_FORM_URL_ENCODED.value)
         )
-        return response.body
+        return response
     }
 }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerTest.kt
@@ -178,7 +178,7 @@ class AuthorizationResponseHandlerTest {
                 any(),
                 any()
             )
-        } returns "success"
+        } returns NetworkResponse(200, "success", mapOf())
     }
 
     @AfterTest
@@ -335,7 +335,7 @@ class AuthorizationResponseHandlerTest {
             responseUri = responseUrl
         )
 
-        assertEquals("success", result)
+        assertEquals("success", result.body)
 
         verify {
             ResponseModeBasedHandlerFactory.get("direct_post")
@@ -771,7 +771,7 @@ class AuthorizationResponseHandlerTest {
             responseUri = responseUrl
         )
 
-        assertEquals("success", result)
+        assertEquals("success", result.body)
 
 
         verify(exactly = 1) {
@@ -845,7 +845,7 @@ class AuthorizationResponseHandlerTest {
             responseUrl
         )
 
-        assertEquals("success", result)
+        assertEquals("success", result.body)
     }
 
     @Test
@@ -1006,7 +1006,7 @@ class AuthorizationResponseHandlerTest {
             responseUri = responseUrl
         )
 
-        assertEquals("success", result)
+        assertEquals("success", result.body)
         // assert if mockResponseHandler is called with correct authorization response
         verify(exactly = 1) {
             mockResponseHandler.sendAuthorizationResponse(

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostJwtResponseModeHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostJwtResponseModeHandlerTest.kt
@@ -162,6 +162,6 @@ class DirectPostJwtResponseModeHandlerTest {
                 headers = mapOf("Content-Type" to ContentType.APPLICATION_FORM_URL_ENCODED.value)
             )
         }
-        assertEquals(vpShareSuccessResponse, actualResponse)
+        assertEquals(vpShareSuccessResponse, actualResponse.body)
     }
 }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostResponseModeHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostResponseModeHandlerTest.kt
@@ -62,7 +62,7 @@ class DirectPostResponseModeHandlerTest {
                 headers = mapOf("Content-Type" to ContentType.APPLICATION_FORM_URL_ENCODED.value)
             )
         }
-        assertEquals(expectedResponse, actualResponse)
+        assertEquals(expectedResponse, actualResponse.body)
     }
 
     @Test
@@ -114,6 +114,6 @@ class DirectPostResponseModeHandlerTest {
             walletNonce
         )
 
-        assertEquals("", actualResponse)
+        assertEquals("", actualResponse.body)
     }
 }


### PR DESCRIPTION
- shareVerifiablePresentation method is depreacated now
- use sendAuthorizationResponseToVerifier instead Reason: shareVerifiablePresentation returns only the verifier response's response body so new method is introduced to send the entire verifier response as network response


Note: A new PR will be raised with detailed deprecation note , doc update and improved test coverage