### PR TITLE
[INJIMOB-3720] refactor: update param name authRequest to authorizationRequest in authenticateVerifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,48 @@ Description: Implementation of OpenID for Verifiable Presentations - in Kotlin
 | Authorization Response content encryption algorithms       | `A256GCM`                                                                                                                                                                                                                                                                                                                                         |
 | Authorization Response key encryption algorithms           | `ECDH-ES`                                                                                                                                                                                                                                                                                                                                         |
 | Credential formats                                         | `ldp_vc`, `mso_mdoc`, `dc+sd-jwt`, `vc+sd-jwt`                                                                                                                                                                                                                                                                                                    |
-| Authorization Response mode                                | `direct_post`, `direct_post.jwt` (with encrypted & unsigned responses)                                                                                                                                                                                                                                                                            |
+| Authorization Response mode                                | `direct_post`, `direct_post.jwt` (with encrypted & unsigned responses) and `iar-post` (unencrypted response), `iar-post.jwt` (Encrypted and unsigned response)                                                                                                                                                                                    |
 | Authorization Response type                                | `vp_token`                                                                                                                                                                                                                                                                                                                                        |
 
 ### Client ID Schemes and Signed / Unsigned request support matrix
 
-| Client Id Scheme | Supports Unsigned request             | Supports Signed request | Notes                                                                                                                                                                                                                                                           |
-|------------------|---------------------------------------|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `pre-registered` | depends ⚖️ on pre-registered Verifier | ✅                      | When `shouldValidateClient` is true, unsigned requests are allowed only if the pre-registered verifier's `allowUnsignedRequest` is true. Otherwise, unsigned requests are always allowed. For signed requests, the trusted verifier's `jwks_uri` is used for validation. |
-| `redirect_uri`   | ✅                                     | ❌                      | Signed request is not supported, since this client ID scheme mandates unsigned Authorization Request as per the specification. [(reference)](https://openid.net/specs/openid-4-verifiable-presentations-1_0-ID3.html#section-5.10.4-2.1)                        |
-| `did`            | ❌                                     | ✅                      | Only signed Authorization Requests are allowed. Requests can be sent by value or by reference, but must always be signed.                                                                                                                                       |
+| Client Id Scheme | Supports Unsigned request             | Supports Signed request | Notes                                                                                                                                                                                                                                                                    |
+|------------------|---------------------------------------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `pre-registered` | depends ⚖️ on pre-registered Verifier | ✅                       | When `shouldValidateClient` is true, unsigned requests are allowed only if the pre-registered verifier's `allowUnsignedRequest` is true. Otherwise, unsigned requests are always allowed. For signed requests, the trusted verifier's `jwks_uri` is used for validation. |
+| `redirect_uri`   | ✅                                     | ❌                       | Signed request is not supported, since this client ID scheme mandates unsigned Authorization Request as per the specification. [(reference)](https://openid.net/specs/openid-4-verifiable-presentations-1_0-ID3.html#section-5.10.4-2.1)                                 |
+| `did`            | ❌                                     | ✅                       | Only signed Authorization Requests are allowed. Requests can be sent by value or by reference, but must always be signed.                                                                                                                                                |
 
 **Note:** 
 - All `By Reference` requests are fetched using HTTP GET / POST method and expected to be _**signed**_ JWT.
 - All `By Value` requests are either _**signed**_ JWT or URL-encoded parameters (_**unsigned**_).
+
+### Notes on Supported response modes
+1. `direct_post` :
+    - Authorization Response is sent as a POST request to the `response_uri` endpoint. Authorization Response is attached as request body in `application/x-www-form-urlencoded` HTTP content type
+2. `direct_post.jwt` :
+    - Authorization Response is sent as a POST request to the `response_uri` endpoint.
+    - Authorization Response is attached as request body in `application/x-www-form-urlencoded` HTTP content type.
+    - The response is encrypted using the public key provided in the client_metadata of the authorization request.
+    - The created JWE's header contains the `apu` (producer info) as wallet generated nonce (with entropy 16 bytes) and `apv` (recipient info) as the verifier nonce i.e., the nonce received in the authorization request.
+   > Note: If the Authorization request includes an `mso_mdoc` format VP, it can only use the `direct_post.jwt` response mode, as required by the ISO-18013-7 specification. Other supported response mode (`direct_post`) is not applicable.
+3. `iar-post` :
+    - Authorization Response is constructed in unencrypted format.
+    - Sample Authorization response structure:
+   ```shell
+    {
+      "vp_token": <verifiable-presentation-token>,
+      "presentation_submission": { ... }
+    }
+    ```
+4. `iar-post.jwt` :
+    - Authorization Response is constructed in encrypted format (and unsigned) using the public key provided in the client_metadata of the authorization request.
+    - The created JWE's header contains the apu (producer info) as wallet generated nonce (with entropy 16 bytes) and apv (recipient info) as the verifier nonce i.e., the nonce received in the authorization request.
+    - Sample Authorization response structure:
+   ```shell
+    {
+      "response": <encryoted data of vp_token & presentation_submission>
+    }
+    ```
 
 ## Specifications supported
 - The implementation follows OpenID for Verifiable Presentations - [draft 21](https://openid.net/specs/openid-4-verifiable-presentations-1_0-21.html) and [draft 23](https://openid.net/specs/openid-4-verifiable-presentations-1_0-23.html) specification.

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -121,7 +121,9 @@ The following credential formats are supported for sharing:
 - [APIs](#apis)
   - [authenticateVerifier](#authenticateverifier)
   - [constructUnsignedVPToken](#constructunsignedvptoken)
+  - [constructVPResponse](#constructvpresponse)
   - [sendVPResponseToVerifier](#sendvpresponsetoverifier)
+  - [constructErrorInfo](#constructerrorinfo)
   - [sendErrorInfoToVerifier](#senderrorinfotoverifier)
 
 
@@ -226,46 +228,68 @@ io.mosip.openID4VP/
 ## APIs
 
 ### authenticateVerifier
-- Accepts a URL-encoded Authorization Request from the Verifier and a list of trusted Verifiers provided by the consumer app (e.g., mobile wallet).
-- Optionally accepts wallet metadata to be shared with the verifier.
-- Decodes and parses the QR code data to determine if it contains a `request_uri` or the complete Authorization Request data.
-- If the data contains `request_uri` and `request_uri_method` as POST, the wallet metadata is included in the request body when making an API call to fetch the Authorization Request.
-- Validates the incoming authorization request with the provided wallet metadata.
-- Constructs the Authorization request object based on the `client_id_scheme`.
-- Includes an optional boolean parameter to enable or disable client validation.
-- Sets the response URI for communication with the verifier.
-- Returns the validated Authorization request object.
+
+- Validates the Verifier's Authorization request received from the Wallet and returns the valid Authorization request object.
+- This method is overloaded to support different ways of Verifier's Authorization request data either as encoded string or as Map of parameters.
+- This method does the following:
+    - Receives a list of trusted verifiers & Verifier's Authorization request from consumer (of the library, example - Wallet app).
+    - Takes an optional boolean to toggle the client validation.
+    - Decodes and parse the request, extracts the clientId and verifies it against trusted verifier's list clientId if clientId is identified to have `pre_registered` clientId scheme.
+    - If the data contains `request_uri` and `request_uri_method` as post, then the wallet metadata is shared in the request body while making an api call to request_uri for fetching authorization request.
+    - The library also validates the incoming authorization request with the wallet metadata passed during the instantiation of OpenID4VP class.
 
 **Note 1:** Wallet can send the entire metadata, library will customize it as per authorization request client_id_scheme. Eg - in case pre-registered, library modifies wallet metadata to be sent without request object signing info properties as specified in the specification.
 
 **Note 2:** Currently the library does not support limit disclosure for any format of VC. It will throw an error if the request contains `presentation_definition` or `presentation_definition_uri` with `input_descriptors` and `limit_disclosure` set to required.
 
+#### Overloads
+
+##### 1. Validates the Authorization request received as URL Encoded string
+
+```kotlin
+    val authorizationRequest : AuthorizationRequest = openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: String, trustedVerifiers: List<Verifier>, shouldValidateClient: Boolean)
+```
+
+##### 2. Validates the Authorization request received as Map of parameters
+
+```kotlin
+    val authorizationRequest : AuthorizationRequest = openID4VP.authenticateVerifier(authorizationRequest: Map<String, Any>, trustedVerifiers: List<Verifier>, shouldValidateClient: Boolean)
+```
 
 ``` kotlin
 //NOTE: New API contract
  val authorizationRequest: AuthorizationRequest = openID4VP.authenticateVerifier(
                                     urlEncodedAuthorizationRequest: String, 
-                                    trustedVerifierJSON: List<Verifier>,
-                                    shouldValidateClient: Boolean = false,
-                                    walletMetadata: WalletMetadata? = null)
+                                    trustedVerifiers: List<Verifier>,
+                                    shouldValidateClient: Boolean = false)
                                     
-//NOTE: Old API contract for backward compatibility
+//NOTE: Old API contract (with walletMetadata parameter) for backward compatibility
  val authorizationRequest: AuthorizationRequest = openID4VP.authenticateVerifier(
                                     urlEncodedAuthorizationRequest: String, 
-                                    trustedVerifierJSON: List<Verifier>,
-                                    shouldValidateClient: Boolean = false)
+                                    trustedVerifiers: List<Verifier>,
+                                    shouldValidateClient: Boolean = false,
+                                    walletMetadata: WalletMetadata?)
 ```
 
 #### Request Parameters
 
-| Name                            | Type             | Description                                                                                                                                                             |
-|---------------------------------|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| urlEncodedAuthorizationRequest  | String           | URL encoded query parameter string containing the Verifier's authorization request                                                                                      |
-| trustedVerifiers                | List\<Verifier\> | A list of trusted Verifier objects each containing a clientId, responseUri, jwksUri and allowUnsignedRequest list (refer [here](#verifier-parameters) for more details) |
-| walletMetadata                  | WalletMetadata?  | Nullable WalletMetadata to be shared with Verifier                                                                                                                      |
-| shouldValidateClient            | Boolean?         | Nullable Boolean with default value false to toggle client validation for pre-registered client id scheme                                                               |
+| Name                           | Type             | Required | Default Value | Description                                                                                                                                                                                                                                    |
+|--------------------------------|------------------|----------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| urlEncodedAuthorizationRequest | String           | Yes      | N/A           | URL encoded query parameter string containing the Verifier's authorization request                                                                                                                                                             |
+| authorizationRequest           | [String : Any]   | Yes      | N/A           | authorization request                                                                                                                                                                                                                          |
+| trustedVerifiers               | List\<Verifier\> | Yes      | N/A           | A list of trusted Verifier objects each containing a clientId, responseUri, jwksUri and allowUnsignedRequest which is used to verify if the Authorization Request if from known Verifier (refer [here](#verifier-parameters) for more details) |
+| walletMetadata (deprecated*)   | WalletMetadata?  | No       | N/A           | Nullable WalletMetadata to be shared with Verifier (Note: Available in Old deprecated API contract, walletMetadata is now passed as a constructor parameter of OpenID4VP class)                                                                |
+| shouldValidateClient           | Boolean          | No       | true          | Boolean to toggle client validation for pre-registered client id scheme                                                                                                                                                                        |
 
-#### Response
+#### Response Parameters
+
+
+| Type                 | Description                                 |
+|----------------------|---------------------------------------------|
+| AuthorizationRequest | The validated Authorization Request object. |
+
+Example AuthorizationRequest object:
+
 ```kotlin
 val authorizationRequest = AuthorizationRequest(
     clientId = "https://mock-verifier.com",
@@ -335,11 +359,40 @@ val walletMetadata = WalletMetadata(
     authorizationEncryptionAlgValuesSupported = listOf(KeyManagementAlgorithm.ECDH_ES),
     authorizationEncryptionEncValuesSupported = listOf(ContentEncrytionAlgorithm.A256GCM)
 )
+
+// Usage with URL Encoded Authorization Request
+
+val urlEncodedAuthorizationRequest: String = """
+        openid4vp://authorize?
+          client_id=did%3Aweb%verifier.inji.net%3Av1%3Averify
+          &client_metadata=...
+          &request_uri=https%3A%2F%2Fclient.example.org%2Frequest%2Fvapof4ql2i7m41m68uep
+          &request_uri_method=post HTTP/1.1
+        """
+
 val authorizationRequest: AuthorizationRequest = openID4VP.authenticateVerifier(
-                    urlEncodedAuthorizationRequest = encodedAuthorizationRequest,
+                    urlEncodedAuthorizationRequest = urlEncodedAuthorizationRequest,
                     trustedVerifiers = trustedVerifiers,
                     shouldValidateClient = true
                 )
+
+// Usage with Map of parameters Authorization Request
+
+val authorizationRequestMap: Map<String, Any> = mapOf(
+    "client_id" to "mock-client",
+    "response_type" to "vp_token",
+    "response_mode" to "direct_post",
+    "presentation_definition" to mapOf(/*...*/),
+    "nonce" to "random-nonce",
+    "state" to "random-state",
+    "redirect_uri" to "https://mock-verifier.com/response"
+)
+
+val authorizationRequest: AuthorizationRequest = openID4VP.authenticateVerifier(
+    authorizationRequest = authorizationRequestMap,
+    trustedVerifiers = trustedVerifiers,
+    shouldValidateClient = true
+)
 ```
 
 #### WalletMetadata Parameters
@@ -486,6 +539,76 @@ val unsignedVPToken: String = """
 
 This method will also notify the Verifier about the error by sending it to the response_uri endpoint over http post request. If response_uri is invalid and validation failed then Verifier won't be able to know about it.
 
+### constructVPResponse
+- Constructs a `vp_token` with proof using the provided `VPTokenSigningResult` and `presentation_submission` which can be sent to the Verifier (Verifying party).
+- Returns back a map of VP response as per the response mode.
+
+**Note 1:** When sharing multiple MSO_MDOC credentials, the verifier is responsible for mapping each credential to its corresponding input descriptor. This mapping is not handled by the library since the ISO standard does not define such a mapping mechanism.
+
+
+```kotlin
+    val response : Map<String, Any> = openID4VP.constructVPResponse(vpTokenSigningResults: Map<FormatType, VPTokenSigningResult>)
+```
+
+#### Request Parameters
+
+| Name                  | Type                                  | Description                                                                                                                                                   |
+|-----------------------|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| vpTokenSigningResults | Map<FormatType, VPTokenSigningResult> | This will be a map with key as credential format and value as VPTokenSigningResult (which is specific to respective credential format's required information) |
+
+### Response Parameters
+
+Map<String, Any> contains the following properties:
+
+1. If the response mode is related to unencrypted - `direct_post` or `iar-post`:
+    - "vp_token": The constructed VP token.
+    - "presentation_submission": The presentation submission as a Map<String, Any>.
+2. If response mode is related to encrypted - `direct_post.jwt` or `iar-post.jwt`:
+    - "response": The encrypted data of the VP response with payload of the JWT containing `vp_token` and `presentation_submission`.
+
+
+#### Example usage
+
+```kotlin
+ val ldpVPTokenSigningResult = LdpVPTokenSigningResult(
+    jws = "ey....qweug",
+    signatureAlgorithm = "RsaSignature2018",
+    publicKey = publicKey,
+    domain = "<domain>"
+)
+val mdocVPTokenSigningResult = MdocVPTokenSigningResult(
+    docTypeToDeviceAuthentication = mapOf(
+        "<mdoc-docType>" to DeviceAuthentication(
+            signature = "ey....qweug",
+            algorithm = "ES256",
+        )
+    )
+)
+val sdJwtVPTokenSigningResult = SdJwtVPTokenSigningResult(
+    uuidToKbJWTSignature = mapOf(
+        "uuid" to "signature" // only signature part of the signed kb-jwt
+    )
+)
+val vpTokenSigningResults : Map<FormatType, VPTokenSigningResult> = mapOf(
+    FormatType.LDP_VC to ldpVPTokenSigningResult,
+    FormatType.MSO_MDOC to mdocVPTokenSigningResult,
+    FormatType.VC_SD_JWT to sdJwtVPTokenSigningResult,
+    FormatType.DC_SD_JWT to sdJwtVPTokenSigningResult,
+)
+val response : Map<String,Any> = openID4VP.constructVPResponse(vpTokenSigningResults = vpTokenSigningResults)
+```
+
+
+#### Exceptions
+
+1. JsonEncodingFailed exception is thrown if there is any issue while serializing the generating vp_token or presentation_submission class instances.
+2. InterruptedIOException is thrown if the connection is timed out when network call is made.
+3. NetworkRequestFailed exception is thrown when there is any other exception occurred when sending the response over http post request.
+4. InvalidData exception is thrown if the response_type in the authorization request is not supported
+
+This method will also notify the Verifier about the error by sending it to the response_uri endpoint over http post request. If response_uri is invalid and validation failed then Verifier won't be able to know about it.
+
+
 ### sendVPResponseToVerifier
 - Constructs a `vp_token` with proof using the provided `VPTokenSigningResult`, then sends it along with the `presentation_submission` to the Verifier via an HTTP POST request.
 - Returns back the response received from the Verifier. Refer here for the structure of VerifierResponse - [VerifierResponse structure](#verifierresponse-structure)
@@ -575,8 +698,8 @@ This method will also notify the Verifier about the error by sending it to the r
 
 #### Request Parameters
 
-| Name                    | Type                                  | Description                                                                                                                                                   |
-|-------------------------|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Name                  | Type                                  | Description                                                                                                                                                   |
+|-----------------------|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | vpTokenSigningResults | Map<FormatType, VPTokenSigningResult> | This will be a map with key as credential format and value as VPTokenSigningResult (which is specific to respective credential format's required information) |
 
 
@@ -621,6 +744,52 @@ val response : String = openID4VP.shareVerifiablePresentation(vpTokenSigningResu
 
 This method will also notify the Verifier about the error by sending it to the response_uri endpoint over http post request. If response_uri is invalid and validation failed then Verifier won't be able to know about it.
 
+### constructErrorInfo
+
+- Receives an exception and constructs the Authorization Error response as per OpenID4VP specification.
+- Returns back the constructed error response as a Map<String, Any>.
+
+#### Request Parameters
+
+| Name      | Type      | Description                                 |
+|-----------|-----------|---------------------------------------------|
+| exception | Exception | The Exception related to the error occurred |
+
+#### Response Parameters
+
+| Type             | Description                                                                                                                      |
+|------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| Map<String, Any> | This will be a map with error and error_description which is the Authorization Error response as per the OpenID4VP specification |
+
+##### Example Response
+
+```shell
+{
+  "error" : "access_Denied"
+  "error_description" : "User did not give consent to share the requested Credentials with the Verifier.",
+  "state" : "<state>"
+}
+```
+
+
+#### Example usage
+
+```kotlin
+// Example: The user declines to share the requested credentials. In this case, Verifier needs to be informed about the scenario.
+// So call the sendErrorInfoToVerifier method with appropriate exception message to notify the Verifier.
+
+val verifierResponse: Map<String,Any> = openID4VP.constructErrorInfo(
+    OpenID4VPExceptions.AccessDenied(
+        message = "User did not give consent to share the requested Credentials with the Verifier.",
+        className = this.className
+    )
+)
+```
+#### Exceptions
+
+1. ErrorDispatchFailure is thrown if any issue occurs while sending the Authorization Error response to the Verifier.
+
+ 
 ### sendErrorInfoToVerifier
 
 - Receives an exception and sends it's message to the Verifier via an HTTP POST request to the Verifier's response_uri endpoint.

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
@@ -60,7 +60,7 @@ class OpenID4VP @JvmOverloads constructor(
     ): AuthorizationRequest {
         return try {
             walletNonce = generateNonce()
-            this@OpenID4VP.authorizationRequest = null
+            this.authorizationRequest = null
             responseUri = null
             authorizationResponseHandler = AuthorizationResponseHandler()
             val validatedAuthorizationRequest =

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
@@ -53,26 +53,26 @@ class OpenID4VP @JvmOverloads constructor(
 
     @JvmOverloads
     fun authenticateVerifier(
-        authRequest: Map<String, Any>,
+        authorizationRequest: Map<String, Any>,
         trustedVerifiers: List<Verifier>,
         shouldValidateClient: Boolean = true,
     ): AuthorizationRequest {
         return try {
             walletNonce = generateNonce()
-            authorizationRequest = null
+            this@OpenID4VP.authorizationRequest = null
             responseUri = null
             authorizationResponseHandler = AuthorizationResponseHandler()
-            val authorizationRequest =
+            val validatedAuthorizationRequest =
                 AuthorizationRequest.validateAndCreateAuthorizationRequest(
-                    authRequest,
+                    authorizationRequest,
                     trustedVerifiers,
                     walletMetadata,
                     ::setResponseUri,
                     shouldValidateClient,
                     walletNonce
                 )
-            this.authorizationRequest = authorizationRequest
-            authorizationRequest
+            this.authorizationRequest = validatedAuthorizationRequest
+            validatedAuthorizationRequest
         } catch (exception: OpenID4VPExceptions) {
             this.safeSendError(exception)
             throw exception

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
@@ -107,7 +107,7 @@ class OpenID4VP @JvmOverloads constructor(
         vpTokenSigningResults: Map<FormatType, VPTokenSigningResult>
     ): VerifierResponse {
         return try {
-            authorizationResponseHandler.shareVP(
+            authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
                 authorizationRequest = authorizationRequest!!,
                 vpTokenSigningResults = vpTokenSigningResults,
                 responseUri = responseUri!!

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
@@ -4,6 +4,7 @@ package io.mosip.openID4VP
 import io.mosip.openID4VP.authorizationRequest.*
 import io.mosip.openID4VP.authorizationResponse.*
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPTokenV2
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.*
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.VPResponseMetadata
 import io.mosip.openID4VP.constants.*
@@ -99,6 +100,38 @@ class OpenID4VP @JvmOverloads constructor(
             throw exception
         }
     }
+
+    fun constructUnsignedVPTokenV2(
+        verifiableCredentials: Map<String, Map<FormatType, List<Any>>>,
+        holderId: String? = null,
+        signatureSuite: String? = null
+    ): List<UnsignedVPTokenV2> {
+        return try {
+            authorizationResponseHandler.constructUnsignedVPTokenV2(
+                credentialsMap = verifiableCredentials,
+                authorizationRequest = authorizationRequest!!,
+                responseUri = responseUri!!,
+                holderId = holderId,
+                signatureSuite = signatureSuite,
+                nonce = walletNonce
+            )
+        } catch (exception: OpenID4VPExceptions) {
+            this.safeSendError(exception)
+            throw exception
+        }
+    }
+
+    fun constructVPResponseV2(vpTokenSigningResults: List<VPTokenSigningResultV2>): Map<String, Any> {
+        return try {
+            authorizationResponseHandler.constructVPResponseV2(
+                authorizationRequest = authorizationRequest!!,
+                vpTokenSigningResults = vpTokenSigningResults
+            )
+        } catch (exception: OpenID4VPExceptions) {
+            return constructErrorInfo(exception)
+        }
+    }
+
 
     /** Sends the final Authorization response to Verifier with the Verifiable Presentations as per response type
      * Returns the Verifier response as Verifier Response object

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
@@ -125,7 +125,7 @@ class OpenID4VP @JvmOverloads constructor(
         return try {
             authorizationResponseHandler.constructVPResponseV2(
                 authorizationRequest = authorizationRequest!!,
-                vpTokenSigningResults = vpTokenSigningResults
+                vpTokenSigningResults = vpTokenSigningResults,
             )
         } catch (exception: OpenID4VPExceptions) {
             return constructErrorInfo(exception)

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionUtil.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/presentationDefinition/PresentationDefinitionUtil.kt
@@ -152,8 +152,8 @@ private fun validateResponseModeForMsoMdocFormat(presentationDefinitionObj: Pres
                 it.format?.containsKey("mso_mdoc") ?: false
             }
 
-    if (hasMsoMdocFormat && responseMode != ResponseMode.DIRECT_POST_JWT.value) {
-        throw OpenID4VPExceptions.InvalidData("When mso_mdoc format is present in presentation definition, response_mode must be direct_post.jwt", className)
+    if (hasMsoMdocFormat && (responseMode != ResponseMode.DIRECT_POST_JWT.value && responseMode != ResponseMode.IAR_POST_JWT.value)) {
+        throw OpenID4VPExceptions.InvalidData("When mso_mdoc format is present in presentation definition, response_mode must be direct_post.jwt or iar-post.jwt", className)
 
     }
 }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
@@ -1,22 +1,14 @@
 package io.mosip.openID4VP.authorizationResponse
 
-import co.nstant.`in`.cbor.CborDecoder
-import co.nstant.`in`.cbor.model.ByteString
-import co.nstant.`in`.cbor.model.NegativeInteger
-import co.nstant.`in`.cbor.model.UnicodeString
-import co.nstant.`in`.cbor.model.UnsignedInteger
 import io.mosip.openID4VP.OpenID4VP
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest
 import io.mosip.openID4VP.authorizationResponse.presentationSubmission.DescriptorMap
 import io.mosip.openID4VP.authorizationResponse.presentationSubmission.PresentationSubmission
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPTokenV2
-import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.UnsignedLdpVPToken
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.UnsignedLdpVPTokenBuilder
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.VPTokenSigningPayload
-import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.mdoc.UnsignedMdocVPToken
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.mdoc.UnsignedMdocVPTokenBuilder
-import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.sdJwt.UnsignedSdJwtVPToken
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.sdJwt.UnsignedSdJwtVPTokenBuilder
 import io.mosip.openID4VP.authorizationResponse.vpToken.VPToken
 import io.mosip.openID4VP.authorizationResponse.vpToken.VPTokenFactory
@@ -26,36 +18,27 @@ import io.mosip.openID4VP.authorizationResponse.vpToken.VPTokenType.VPTokenEleme
 import io.mosip.openID4VP.authorizationResponse.vpToken.types.ldp.LdpVPToken
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResultV2
-import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.LdpVPTokenSigningResult
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.VPResponseMetadata
-import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.mdoc.DeviceAuthentication
-import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.mdoc.MdocVPTokenSigningResult
-import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.sdJwt.SdJwtVPTokenSigningResult
 import io.mosip.openID4VP.common.OpenID4VPErrorFields
 import io.mosip.openID4VP.common.UUIDGenerator
-import io.mosip.openID4VP.common.encodeCbor
-import io.mosip.openID4VP.common.encodeToBase64Url
 import io.mosip.openID4VP.common.encodeToJsonString
 import io.mosip.openID4VP.common.flattenUnsignedTokensV2
-import io.mosip.openID4VP.common.getDecodedMdocCredential
 import io.mosip.openID4VP.common.reconstructSigningResultsV2
 import io.mosip.openID4VP.constants.ContentType
 import io.mosip.openID4VP.constants.FormatType
 import io.mosip.openID4VP.constants.HttpMethod
 import io.mosip.openID4VP.constants.ResponseMode
 import io.mosip.openID4VP.constants.ResponseType
+import io.mosip.openID4VP.constants.SignatureSuiteAlgorithm
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
-import io.mosip.openID4VP.jwt.jws.JWSHandler
 import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
 import io.mosip.openID4VP.networkManager.NetworkResponse
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandlerFactory
 import io.mosip.openID4VP.verifier.VerifierResponse
-import io.mosip.vercred.vcverifier.keyResolver.types.did.DidPublicKeyResolver
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
-import java.io.ByteArrayInputStream
 
 private val className = AuthorizationResponseHandler::class.java.simpleName
 
@@ -67,6 +50,7 @@ private val className = AuthorizationResponseHandler::class.java.simpleName
 internal class AuthorizationResponseHandler {
     private lateinit var unsignedVPTokenResults: Map<FormatType, Pair<VPTokenSigningPayload?, UnsignedVPToken>>
     private lateinit var walletNonce: String
+    private lateinit var signatureSuite: String
     private lateinit var formatToCredentialInputDescriptorMapping: Map<FormatType, List<CredentialInputDescriptorMapping>>
 
     internal fun constructUnsignedVPToken(
@@ -96,6 +80,7 @@ internal class AuthorizationResponseHandler {
                 )
             }
         }
+        this.signatureSuite = signatureSuite ?: SignatureSuiteAlgorithm.Ed25519Signature2020.value
 
         return createUnsignedVPToken(
             credentialsMap,
@@ -134,13 +119,14 @@ internal class AuthorizationResponseHandler {
 
     internal fun constructVPResponseV2(
         vpTokenSigningResults: List<VPTokenSigningResultV2>,
-        authorizationRequest: AuthorizationRequest
+        authorizationRequest: AuthorizationRequest,
     ): Map<String, String> {
 
         val reconstructedResults = reconstructSigningResultsV2(
             unsignedVPTokenResults = unsignedVPTokenResults,
             formatMappings = formatToCredentialInputDescriptorMapping,
             signingResults = vpTokenSigningResults,
+            signatureSuite = this.signatureSuite,
             className = className
         )
 

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
@@ -1,13 +1,22 @@
 package io.mosip.openID4VP.authorizationResponse
 
+import co.nstant.`in`.cbor.CborDecoder
+import co.nstant.`in`.cbor.model.ByteString
+import co.nstant.`in`.cbor.model.NegativeInteger
+import co.nstant.`in`.cbor.model.UnicodeString
+import co.nstant.`in`.cbor.model.UnsignedInteger
 import io.mosip.openID4VP.OpenID4VP
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest
 import io.mosip.openID4VP.authorizationResponse.presentationSubmission.DescriptorMap
 import io.mosip.openID4VP.authorizationResponse.presentationSubmission.PresentationSubmission
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPTokenV2
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.UnsignedLdpVPToken
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.UnsignedLdpVPTokenBuilder
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.VPTokenSigningPayload
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.mdoc.UnsignedMdocVPToken
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.mdoc.UnsignedMdocVPTokenBuilder
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.sdJwt.UnsignedSdJwtVPToken
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.sdJwt.UnsignedSdJwtVPTokenBuilder
 import io.mosip.openID4VP.authorizationResponse.vpToken.VPToken
 import io.mosip.openID4VP.authorizationResponse.vpToken.VPTokenFactory
@@ -16,24 +25,37 @@ import io.mosip.openID4VP.authorizationResponse.vpToken.VPTokenType.VPTokenArray
 import io.mosip.openID4VP.authorizationResponse.vpToken.VPTokenType.VPTokenElement
 import io.mosip.openID4VP.authorizationResponse.vpToken.types.ldp.LdpVPToken
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResultV2
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.LdpVPTokenSigningResult
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.VPResponseMetadata
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.mdoc.DeviceAuthentication
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.mdoc.MdocVPTokenSigningResult
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.sdJwt.SdJwtVPTokenSigningResult
 import io.mosip.openID4VP.common.OpenID4VPErrorFields
 import io.mosip.openID4VP.common.UUIDGenerator
+import io.mosip.openID4VP.common.encodeCbor
+import io.mosip.openID4VP.common.encodeToBase64Url
 import io.mosip.openID4VP.common.encodeToJsonString
+import io.mosip.openID4VP.common.flattenUnsignedTokensV2
+import io.mosip.openID4VP.common.getDecodedMdocCredential
+import io.mosip.openID4VP.common.reconstructSigningResultsV2
 import io.mosip.openID4VP.constants.ContentType
 import io.mosip.openID4VP.constants.FormatType
 import io.mosip.openID4VP.constants.HttpMethod
 import io.mosip.openID4VP.constants.ResponseMode
 import io.mosip.openID4VP.constants.ResponseType
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
+import io.mosip.openID4VP.jwt.jws.JWSHandler
 import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
 import io.mosip.openID4VP.networkManager.NetworkResponse
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandlerFactory
 import io.mosip.openID4VP.verifier.VerifierResponse
-import kotlinx.serialization.json.contentOrNull
+import io.mosip.vercred.vcverifier.keyResolver.types.did.DidPublicKeyResolver
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.ByteArrayInputStream
 
 private val className = AuthorizationResponseHandler::class.java.simpleName
 
@@ -84,6 +106,51 @@ internal class AuthorizationResponseHandler {
             nonce
         )
     }
+
+    internal fun constructUnsignedVPTokenV2(
+        credentialsMap: Map<String, Map<FormatType, List<Any>>>,
+        holderId: String?,
+        authorizationRequest: AuthorizationRequest,
+        responseUri: String,
+        signatureSuite: String?,
+        nonce: String
+    ): List<UnsignedVPTokenV2> {
+        constructUnsignedVPToken(
+            credentialsMap = credentialsMap,
+            holderId = holderId,
+            authorizationRequest = authorizationRequest,
+            responseUri = responseUri,
+            signatureSuite = signatureSuite,
+            nonce = nonce
+        )
+
+        return flattenUnsignedTokensV2(
+            unsignedVPTokenResults = unsignedVPTokenResults,
+            formatMappings = formatToCredentialInputDescriptorMapping,
+            signatureSuite = signatureSuite,
+            className = className
+        )
+    }
+
+    internal fun constructVPResponseV2(
+        vpTokenSigningResults: List<VPTokenSigningResultV2>,
+        authorizationRequest: AuthorizationRequest
+    ): Map<String, String> {
+
+        val reconstructedResults = reconstructSigningResultsV2(
+            unsignedVPTokenResults = unsignedVPTokenResults,
+            formatMappings = formatToCredentialInputDescriptorMapping,
+            signingResults = vpTokenSigningResults,
+            className = className
+        )
+
+        return constructAuthorizationResponse(
+            authorizationRequest = authorizationRequest,
+            vpTokenSigningResults = reconstructedResults
+        )
+    }
+
+
 
     private fun createUnsignedVPToken(
         credentialsMap: Map<String, Map<FormatType, List<Any>>>,
@@ -211,6 +278,7 @@ internal class AuthorizationResponseHandler {
                 walletNonce
             )
     }
+
 
     //Create authorization response based on the response_type parameter in authorization response
     private fun createAuthorizationResponse(

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
@@ -113,6 +113,7 @@ internal class AuthorizationResponseHandler {
             unsignedVPTokenResults = unsignedVPTokenResults,
             formatMappings = formatToCredentialInputDescriptorMapping,
             signatureSuite = signatureSuite,
+            holderId = holderId,
             className = className
         )
     }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
@@ -22,8 +22,8 @@ import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.V
 import io.mosip.openID4VP.common.OpenID4VPErrorFields
 import io.mosip.openID4VP.common.UUIDGenerator
 import io.mosip.openID4VP.common.encodeToJsonString
-import io.mosip.openID4VP.common.flattenUnsignedTokensV2
-import io.mosip.openID4VP.common.reconstructSigningResultsV2
+import io.mosip.openID4VP.common.flattenUnsignedVPTokens
+import io.mosip.openID4VP.common.constructSigningResults
 import io.mosip.openID4VP.constants.ContentType
 import io.mosip.openID4VP.constants.FormatType
 import io.mosip.openID4VP.constants.HttpMethod
@@ -109,7 +109,7 @@ internal class AuthorizationResponseHandler {
             nonce = nonce
         )
 
-        return flattenUnsignedTokensV2(
+        return flattenUnsignedVPTokens(
             unsignedVPTokenResults = unsignedVPTokenResults,
             formatMappings = formatToCredentialInputDescriptorMapping,
             signatureSuite = signatureSuite,
@@ -123,7 +123,7 @@ internal class AuthorizationResponseHandler {
         authorizationRequest: AuthorizationRequest,
     ): Map<String, String> {
 
-        val reconstructedResults = reconstructSigningResultsV2(
+        val reconstructedResults = constructSigningResults(
             unsignedVPTokenResults = unsignedVPTokenResults,
             formatMappings = formatToCredentialInputDescriptorMapping,
             signingResults = vpTokenSigningResults,

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
@@ -47,7 +47,7 @@ internal class AuthorizationResponseHandler {
     private lateinit var walletNonce: String
     private lateinit var formatToCredentialInputDescriptorMapping: Map<FormatType, List<CredentialInputDescriptorMapping>>
 
-    fun constructUnsignedVPToken(
+    internal fun constructUnsignedVPToken(
         credentialsMap: Map<String, Map<FormatType, List<Any>>>,
         holderId: String?,
         authorizationRequest: AuthorizationRequest,
@@ -177,7 +177,7 @@ internal class AuthorizationResponseHandler {
         }
     }
 
-    fun shareVP(
+    internal fun constructAndSendAuthorizationResponseToVerifier(
         authorizationRequest: AuthorizationRequest,
         vpTokenSigningResults: Map<FormatType, VPTokenSigningResult>,
         responseUri: String,

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/unsignedVPToken/UnsignedVPTokenV2.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/unsignedVPToken/UnsignedVPTokenV2.kt
@@ -1,0 +1,14 @@
+package io.mosip.openID4VP.authorizationResponse.unsignedVPToken
+
+import io.mosip.openID4VP.constants.FormatType
+
+data class UnsignedVPTokenV2(
+
+    val format: FormatType,
+
+    val holderKeyReference: String,
+
+    val signatureAlgorithm: String,
+
+    val dataToSign: String
+)

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/vpTokenSigningResult/VPTokenSigningResultV2.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/vpTokenSigningResult/VPTokenSigningResultV2.kt
@@ -1,0 +1,5 @@
+package io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult
+
+data class VPTokenSigningResultV2(
+    val signedData: String
+)

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
@@ -162,6 +162,7 @@ internal fun flattenUnsignedTokensV2(
     unsignedVPTokenResults: Map<FormatType, Pair<VPTokenSigningPayload?, UnsignedVPToken>>,
     formatMappings: Map<FormatType, List<CredentialInputDescriptorMapping>>,
     signatureSuite: String?,
+    holderId: String?,
     className: String
 ): List<UnsignedVPTokenV2> {
 
@@ -177,6 +178,7 @@ internal fun flattenUnsignedTokensV2(
                 unsignedToken,
                 mappings,
                 signatureSuite,
+                holderId,
                 className
             )
 
@@ -229,6 +231,7 @@ internal fun flattenLdpV2(
     unsignedToken: UnsignedVPToken,
     mappings: List<CredentialInputDescriptorMapping>,
     signatureSuite: String?,
+    holderId: String?,
     className: String
 ): List<UnsignedVPTokenV2> {
 
@@ -237,7 +240,7 @@ internal fun flattenLdpV2(
     val credential = mappings.firstOrNull()?.credential
         ?: throw InvalidData("No LDP credential found", className)
 
-    val holderKeyRef = resolveLdpHolderKey(
+    val holderKeyRef = holderId ?: resolveLdpHolderKey(
         credential,
         className = className
     )
@@ -314,7 +317,10 @@ fun resolveLdpHolderKey(credential: Any, className: String): String {
 fun resolveMdocKeyAndAlg(mdocCredential: String, className: String): Pair<String, String> =
     extractMdocKeyReferenceAndAlg(mdocCredential, className)
 
-private fun extractMdocKeyReferenceAndAlg(mdocCredential: String, className: String): Pair<String, String> {
+private fun extractMdocKeyReferenceAndAlg(
+    mdocCredential: String,
+    className: String
+): Pair<String, String> {
     val decoded = getDecodedMdocCredential(mdocCredential)
 
     val issuerSigned = decoded[UnicodeString("issuerSigned")] as? co.nstant.`in`.cbor.model.Map
@@ -424,11 +430,22 @@ fun reconstructLdpV2(
 
     val signed = iterator.nextOrError("Missing LDP signature", className)
 
-    return LdpVPTokenSigningResult(
-        proofValue = signed.signedData.takeIf { signatureSuite != SignatureSuiteAlgorithm.JsonWebSignature2020.value },
-        jws = signed.signedData.takeIf { signatureSuite == SignatureSuiteAlgorithm.JsonWebSignature2020.value },
-        signatureAlgorithm = signatureSuite
-    )
+    return if (
+        signatureSuite == SignatureSuiteAlgorithm.JsonWebSignature2020.value ||
+        signatureSuite == SignatureSuiteAlgorithm.RSASignature2018.value ||
+        signatureSuite == SignatureSuiteAlgorithm.Ed25519Signature2018.value
+    ) {
+        LdpVPTokenSigningResult(
+            jws = signed.signedData,
+            signatureAlgorithm = signatureSuite
+        )
+    } else {
+        LdpVPTokenSigningResult(
+            proofValue = signed.signedData,
+            jws = null,
+            signatureAlgorithm = signatureSuite
+        )
+    }
 }
 
 internal fun reconstructMdocV2(
@@ -446,7 +463,7 @@ internal fun reconstructMdocV2(
         val signed = iterator.nextOrError("Missing mdoc signature for docType $docType", className)
 
         val mapping = mappings.first { it.identifier == docType }
-        val (_, alg) = resolveMdocKeyAndAlg(mapping.credential as String,className)
+        val (_, alg) = resolveMdocKeyAndAlg(mapping.credential as String, className)
 
         deviceAuthMap[docType] = DeviceAuthentication(signed.signedData, alg)
     }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
@@ -1,23 +1,45 @@
 package io.mosip.openID4VP.common
 
+import co.nstant.`in`.cbor.CborDecoder
+import co.nstant.`in`.cbor.model.ByteString
+import co.nstant.`in`.cbor.model.NegativeInteger
+import co.nstant.`in`.cbor.model.UnicodeString
+import co.nstant.`in`.cbor.model.UnsignedInteger
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mosip.openID4VP.authorizationRequest.clientMetadata.Jwks
+import io.mosip.openID4VP.authorizationResponse.CredentialInputDescriptorMapping
 import io.mosip.openID4VP.authorizationResponse.presentationSubmission.PathNested
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPTokenV2
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.UnsignedLdpVPToken
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.VPTokenSigningPayload
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.mdoc.UnsignedMdocVPToken
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.sdJwt.UnsignedSdJwtVPToken
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResultV2
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.LdpVPTokenSigningResult
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.mdoc.DeviceAuthentication
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.mdoc.MdocVPTokenSigningResult
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.sdJwt.SdJwtVPTokenSigningResult
 import io.mosip.openID4VP.constants.FormatType
 import io.mosip.openID4VP.constants.HttpMethod
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions.InvalidData
+import io.mosip.openID4VP.jwt.jws.JWSHandler
 import io.mosip.openID4VP.networkManager.NetworkManagerClient
 import io.mosip.openID4VP.networkManager.NetworkResponse
+import io.mosip.vercred.vcverifier.keyResolver.types.did.DidPublicKeyResolver
+import java.io.ByteArrayInputStream
 import java.security.MessageDigest
 import java.security.SecureRandom
 
-private const val URL_PATTERN = "^https://(?:[\\w-]+\\.)+[\\w-]+(?:/[\\w\\-.~!$&'()*+,;=:@%]+)*/?(?:\\?[^#\\s]*)?(?:#.*)?$"
+private const val URL_PATTERN =
+    "^https://(?:[\\w-]+\\.)+[\\w-]+(?:/[\\w\\-.~!$&'()*+,;=:@%]+)*/?(?:\\?[^#\\s]*)?(?:#.*)?$"
 
-fun isValidUrl(url : String): Boolean {
+fun isValidUrl(url: String): Boolean {
     return url.matches(URL_PATTERN.toRegex())
 }
 
@@ -62,8 +84,8 @@ fun validate(
     fieldType: String = "String"
 ) {
     if (value == null || value == "null" || value.isEmpty()) {
-        throw if(value == null) {
-            OpenID4VPExceptions.MissingInput(listOf(key),"",className)
+        throw if (value == null) {
+            OpenID4VPExceptions.MissingInput(listOf(key), "", className)
         } else {
             OpenID4VPExceptions.InvalidInput(listOf(key), fieldType, className)
         }
@@ -72,14 +94,19 @@ fun validate(
 
 inline fun <reified T> encodeToJsonString(data: T, fieldName: String, className: String): String {
     try {
-        val objectMapper = jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        val objectMapper =
+            jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
         return objectMapper.writeValueAsString(data)
     } catch (exception: Exception) {
-        throw  OpenID4VPExceptions.JsonEncodingFailed(listOf(fieldName), exception.message.toString(),className)
+        throw OpenID4VPExceptions.JsonEncodingFailed(
+            listOf(fieldName),
+            exception.message.toString(),
+            className
+        )
     }
 }
 
-fun ByteArray.toHex(): String{
+fun ByteArray.toHex(): String {
     return this.joinToString("") { "%02x".format(it) }
 }
 
@@ -93,7 +120,11 @@ fun hashData(data: String, algorithm: String = "SHA-256"): String {
     return encodeToBase64Url(hash)
 }
 
-fun createNestedPath(inputDescriptorId: String, nestedPath: String?, format: FormatType): PathNested? {
+fun createNestedPath(
+    inputDescriptorId: String,
+    nestedPath: String?,
+    format: FormatType
+): PathNested? {
     if (nestedPath == null) return null
     return PathNested(
         id = inputDescriptorId,
@@ -125,3 +156,319 @@ internal fun resolveJwksFromUri(jwksUri: String, className: String): Jwks {
         )
     }
 }
+
+internal fun flattenUnsignedTokensV2(
+    unsignedVPTokenResults: Map<FormatType, Pair<VPTokenSigningPayload?, UnsignedVPToken>>,
+    formatMappings: Map<FormatType, List<CredentialInputDescriptorMapping>>,
+    signatureSuite: String?,
+    className: String
+): List<UnsignedVPTokenV2> {
+
+    val result = mutableListOf<UnsignedVPTokenV2>()
+
+    unsignedVPTokenResults.forEach { (format, pair) ->
+        val unsignedToken = pair.second
+        val mappings = formatMappings[format]
+            ?: throw InvalidData("Missing mapping for $format", className)
+
+        when (format) {
+            FormatType.LDP_VC -> result += flattenLdpV2(
+                unsignedToken,
+                mappings,
+                signatureSuite,
+                className
+            )
+
+            FormatType.MSO_MDOC -> result += flattenMdocV2(unsignedToken, mappings, className)
+            FormatType.DC_SD_JWT, FormatType.VC_SD_JWT -> result += flattenSdJwtV2(
+                unsignedToken,
+                mappings,
+                format,
+                className
+            )
+        }
+    }
+
+    return result
+}
+
+internal fun reconstructSigningResultsV2(
+    unsignedVPTokenResults: Map<FormatType, Pair<VPTokenSigningPayload?, UnsignedVPToken>>,
+    formatMappings: Map<FormatType, List<CredentialInputDescriptorMapping>>,
+    signingResults: List<VPTokenSigningResultV2>,
+    className: String
+): Map<FormatType, VPTokenSigningResult> {
+
+    val iterator = signingResults.iterator()
+
+    val reconstructed = unsignedVPTokenResults.mapValues { (format, pair) ->
+        val unsignedToken = pair.second
+        val mappings = formatMappings[format]!!
+
+        when (format) {
+            FormatType.LDP_VC -> reconstructLdpV2(iterator, className)
+            FormatType.MSO_MDOC -> reconstructMdocV2(unsignedToken, mappings, iterator, className)
+            FormatType.DC_SD_JWT, FormatType.VC_SD_JWT -> reconstructSdJwtV2(
+                unsignedToken,
+                iterator,
+                className
+            )
+        }
+    }
+
+    if (iterator.hasNext()) {
+        throw InvalidData("Extra signing results provided", className)
+    }
+
+    return reconstructed
+}
+
+internal fun flattenLdpV2(
+    unsignedToken: UnsignedVPToken,
+    mappings: List<CredentialInputDescriptorMapping>,
+    signatureSuite: String?,
+    className: String
+): List<UnsignedVPTokenV2> {
+
+    val ldp = unsignedToken as UnsignedLdpVPToken
+
+    val credential = mappings.firstOrNull()?.credential
+        ?: throw InvalidData("No LDP credential found", className)
+
+    val holderKeyRef = resolveLdpHolderKey(
+        credential,
+        className = className
+    )
+
+    return listOf(
+        UnsignedVPTokenV2(
+            format = FormatType.LDP_VC,
+            holderKeyReference = holderKeyRef,
+            signatureAlgorithm = signatureSuite
+                ?: throw InvalidData("signatureSuite required for LDP", className),
+            dataToSign = ldp.dataToSign
+        )
+    )
+}
+
+internal fun flattenMdocV2(
+    unsignedToken: UnsignedVPToken,
+    mappings: List<CredentialInputDescriptorMapping>,
+    className: String
+): List<UnsignedVPTokenV2> {
+
+    val mdoc = unsignedToken as UnsignedMdocVPToken
+
+    return mdoc.docTypeToDeviceAuthenticationBytes.map { (docType, bytesToSign) ->
+
+        val mapping = mappings.firstOrNull { it.identifier == docType }
+            ?: throw InvalidData("No mapping for docType $docType", className)
+
+        val (keyRef, alg) = resolveMdocKeyAndAlg(mapping.credential as String, className)
+
+        UnsignedVPTokenV2(
+            format = FormatType.MSO_MDOC,
+            holderKeyReference = keyRef,
+            signatureAlgorithm = alg,
+            dataToSign = bytesToSign
+        )
+    }
+}
+
+internal fun flattenSdJwtV2(
+    unsignedToken: UnsignedVPToken,
+    mappings: List<CredentialInputDescriptorMapping>,
+    format: FormatType,
+    className: String
+): List<UnsignedVPTokenV2> {
+
+    val sdjwt = unsignedToken as UnsignedSdJwtVPToken
+
+    val uuidToMapping = mappings.mapNotNull { m -> m.identifier?.let { it to m } }.toMap()
+
+    return sdjwt.uuidToUnsignedKBT.map { (uuid, unsignedKbJwt) ->
+
+        val mapping = uuidToMapping[uuid]
+            ?: throw InvalidData("No SD-JWT mapping for uuid $uuid", className)
+
+        val (kid, alg) = resolveSdJwtKeyAndAlg(mapping.credential as String, className)
+
+        UnsignedVPTokenV2(format, kid, alg, unsignedKbJwt)
+    }
+}
+
+fun resolveLdpHolderKey(credential: Any, className: String): String {
+
+    val vcMap = credential as? Map<*, *>
+        ?: throw InvalidData("Invalid LDP credential structure", className)
+
+    val credentialSubject = vcMap["credentialSubject"] as? Map<*, *>
+        ?: throw InvalidData("credentialSubject missing", className)
+
+    return credentialSubject["id"] as? String
+        ?: throw InvalidData("credentialSubject.id missing", className)
+}
+
+fun resolveMdocKeyAndAlg(mdocCredential: String, className: String): Pair<String, String> =
+    extractMdocKeyReferenceAndAlg(mdocCredential, className)
+
+private fun extractMdocKeyReferenceAndAlg(mdocCredential: String, className: String): Pair<String, String> {
+    val decoded = getDecodedMdocCredential(mdocCredential)
+
+    val issuerSigned = decoded[UnicodeString("issuerSigned")] as? co.nstant.`in`.cbor.model.Map
+        ?: throw OpenID4VPExceptions.InvalidData("issuerSigned missing", className)
+
+    val issuerAuthArray =
+        issuerSigned[UnicodeString("issuerAuth")] as? co.nstant.`in`.cbor.model.Array
+            ?: throw OpenID4VPExceptions.InvalidData("issuerAuth not COSE_Sign1", className)
+
+    val payloadBytes = issuerAuthArray.dataItems[2] as? ByteString
+        ?: throw OpenID4VPExceptions.InvalidData("issuerAuth payload missing", className)
+
+    // Decode payload
+    val firstDecoded = CborDecoder(ByteArrayInputStream(payloadBytes.bytes)).decode().first()
+
+    // Handle Tag 24 (encoded CBOR)
+    val msoDataItem = if (firstDecoded.tag?.value == 24L) {
+        val innerBytes = (firstDecoded as? ByteString)?.bytes
+            ?: throw OpenID4VPExceptions.InvalidData("Tag 24 inner not bstr", className)
+
+        CborDecoder(ByteArrayInputStream(innerBytes)).decode().first()
+    } else {
+        firstDecoded
+    }
+
+    val mso = msoDataItem as? co.nstant.`in`.cbor.model.Map
+        ?: throw OpenID4VPExceptions.InvalidData("MSO not map after unwrap", className)
+
+    val deviceKeyInfo = mso[UnicodeString("deviceKeyInfo")] as? co.nstant.`in`.cbor.model.Map
+        ?: throw OpenID4VPExceptions.InvalidData("deviceKeyInfo missing", className)
+
+    val deviceKey = deviceKeyInfo[UnicodeString("deviceKey")] as? co.nstant.`in`.cbor.model.Map
+        ?: throw OpenID4VPExceptions.InvalidData("deviceKey missing", className)
+
+    // 🔑 Key reference
+    val keyBytes = encodeCbor(deviceKey)
+    val keyRef = encodeToBase64Url(keyBytes)
+
+    // 🔐 Algorithm detection
+    val algKey = UnsignedInteger(3)
+    val algItem = deviceKey[algKey]
+
+    val alg = if (algItem != null) {
+        val coseAlg = when (algItem) {
+            is NegativeInteger -> -algItem.value.toInt()
+            is UnsignedInteger -> algItem.value.toInt()
+            else -> throw OpenID4VPExceptions.InvalidData("Invalid alg type", className)
+        }
+
+        when (coseAlg) {
+            -7 -> "ES256"
+            -8 -> "EdDSA"
+            else -> throw OpenID4VPExceptions.InvalidData(
+                "Unsupported COSE alg $coseAlg",
+                className
+            )
+        }
+    } else {
+        // Fallback via curve
+        val crvKey = NegativeInteger(-1)
+        val crvItem = deviceKey[crvKey]
+            ?: throw OpenID4VPExceptions.InvalidData("crv missing for alg inference", className)
+
+        val crv = when (crvItem) {
+            is UnsignedInteger -> crvItem.value.toInt()
+            else -> throw OpenID4VPExceptions.InvalidData("Invalid crv type", className)
+        }
+
+        when (crv) {
+            1 -> "ES256"   // P-256
+            6 -> "EdDSA"   // Ed25519
+            else -> throw OpenID4VPExceptions.InvalidData("Unsupported crv $crv", className)
+        }
+    }
+
+    return keyRef to alg
+}
+
+fun resolveSdJwtKeyAndAlg(sdJwtCredential: String, className: String): Pair<String, String> {
+
+    val sdJwt = sdJwtCredential.split("~")[0]
+    val payload = JWSHandler.extractDataJsonFromJws(sdJwt, JWSHandler.JwsPart.PAYLOAD)
+
+    val cnf = payload["cnf"] as? Map<*, *>
+        ?: throw InvalidData("cnf missing in SD-JWT", className)
+
+    val kid = cnf["kid"] as? String
+        ?: throw InvalidData("cnf.kid missing", className)
+
+    val publicKey = DidPublicKeyResolver().resolve(kid.trimEnd('='), null)
+
+    val alg = when (publicKey.algorithm) {
+        "Ed25519" -> "EdDSA"
+        "EC" -> "ES256"
+        "RSA" -> "RS256"
+        else -> throw InvalidData("Unsupported key algorithm ${publicKey.algorithm}", className)
+    }
+
+    return kid to alg
+}
+
+fun reconstructLdpV2(
+    iterator: Iterator<VPTokenSigningResultV2>,
+    className: String
+): VPTokenSigningResult {
+
+    val signed = iterator.nextOrError("Missing LDP signature", className)
+
+    return LdpVPTokenSigningResult(
+        proofValue = signed.signedData,
+        signatureAlgorithm = "Ed25519Signature2020"
+    )
+}
+
+internal fun reconstructMdocV2(
+    unsignedToken: UnsignedVPToken,
+    mappings: List<CredentialInputDescriptorMapping>,
+    iterator: Iterator<VPTokenSigningResultV2>,
+    className: String
+): VPTokenSigningResult {
+
+    val unsignedMdoc = unsignedToken as UnsignedMdocVPToken
+    val deviceAuthMap = mutableMapOf<String, DeviceAuthentication>()
+
+    unsignedMdoc.docTypeToDeviceAuthenticationBytes.forEach { (docType, _) ->
+
+        val signed = iterator.nextOrError("Missing mdoc signature for docType $docType", className)
+
+        val mapping = mappings.first { it.identifier == docType }
+        val (_, alg) = resolveMdocKeyAndAlg(mapping.credential as String,className)
+
+        deviceAuthMap[docType] = DeviceAuthentication(signed.signedData, alg)
+    }
+
+    return MdocVPTokenSigningResult(deviceAuthMap)
+}
+
+fun reconstructSdJwtV2(
+    unsignedToken: UnsignedVPToken,
+    iterator: Iterator<VPTokenSigningResultV2>,
+    className: String
+): VPTokenSigningResult {
+
+    val unsignedSd = unsignedToken as UnsignedSdJwtVPToken
+
+    val uuidToSig = unsignedSd.uuidToUnsignedKBT.mapValues {
+        iterator.nextOrError(
+            "Missing SD-JWT signature for uuid ${it.key}",
+            className = className
+        ).signedData
+    }
+
+    return SdJwtVPTokenSigningResult(uuidToSig)
+}
+
+private fun <T> Iterator<T>.nextOrError(msg: String, className: String): T =
+    if (hasNext()) next()
+    else throw InvalidData(msg, className)
+

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
@@ -158,7 +158,7 @@ internal fun resolveJwksFromUri(jwksUri: String, className: String): Jwks {
     }
 }
 
-internal fun flattenUnsignedTokensV2(
+internal fun flattenUnsignedVPTokens(
     unsignedVPTokenResults: Map<FormatType, Pair<VPTokenSigningPayload?, UnsignedVPToken>>,
     formatMappings: Map<FormatType, List<CredentialInputDescriptorMapping>>,
     signatureSuite: String?,
@@ -168,13 +168,14 @@ internal fun flattenUnsignedTokensV2(
 
     val result = mutableListOf<UnsignedVPTokenV2>()
 
-    unsignedVPTokenResults.forEach { (format, pair) ->
-        val unsignedToken = pair.second
+    unsignedVPTokenResults.keys.sortedBy { it.value }.forEach { format ->
+        val pair = unsignedVPTokenResults[format]
+        val unsignedToken = pair!!.second
         val mappings = formatMappings[format]
             ?: throw InvalidData("Missing mapping for $format", className)
 
         when (format) {
-            FormatType.LDP_VC -> result += flattenLdpV2(
+            FormatType.LDP_VC -> result += flattenLdp(
                 unsignedToken,
                 mappings,
                 signatureSuite,
@@ -182,8 +183,8 @@ internal fun flattenUnsignedTokensV2(
                 className
             )
 
-            FormatType.MSO_MDOC -> result += flattenMdocV2(unsignedToken, mappings, className)
-            FormatType.DC_SD_JWT, FormatType.VC_SD_JWT -> result += flattenSdJwtV2(
+            FormatType.MSO_MDOC -> result += flattenMdoc(unsignedToken, mappings, className)
+            FormatType.DC_SD_JWT, FormatType.VC_SD_JWT -> result += flattenSdJwt(
                 unsignedToken,
                 mappings,
                 format,
@@ -195,7 +196,7 @@ internal fun flattenUnsignedTokensV2(
     return result
 }
 
-internal fun reconstructSigningResultsV2(
+internal fun constructSigningResults(
     unsignedVPTokenResults: Map<FormatType, Pair<VPTokenSigningPayload?, UnsignedVPToken>>,
     formatMappings: Map<FormatType, List<CredentialInputDescriptorMapping>>,
     signingResults: List<VPTokenSigningResultV2>,
@@ -205,20 +206,30 @@ internal fun reconstructSigningResultsV2(
 
     val iterator = signingResults.iterator()
 
-    val reconstructed = unsignedVPTokenResults.mapValues { (format, pair) ->
-        val unsignedToken = pair.second
-        val mappings = formatMappings[format]!!
+    val reconstructed = mutableMapOf<FormatType, VPTokenSigningResult>()
 
-        when (format) {
-            FormatType.LDP_VC -> reconstructLdpV2(iterator, signatureSuite, className)
-            FormatType.MSO_MDOC -> reconstructMdocV2(unsignedToken, mappings, iterator, className)
-            FormatType.DC_SD_JWT, FormatType.VC_SD_JWT -> reconstructSdJwtV2(
-                unsignedToken,
-                iterator,
-                className
-            )
+    unsignedVPTokenResults.keys
+        .sortedBy { it.value }
+        .forEach { format ->
+
+            val pair = unsignedVPTokenResults[format]!!
+            val unsignedToken = pair.second
+            val mappings = formatMappings[format]!!
+
+            val result = when (format) {
+                FormatType.LDP_VC ->
+                    constructLdp(iterator, signatureSuite, className)
+
+                FormatType.MSO_MDOC ->
+                    constructMdoc(unsignedToken, mappings, iterator, className)
+
+                FormatType.DC_SD_JWT, FormatType.VC_SD_JWT ->
+                    constructSdJwt(unsignedToken, iterator, className)
+            }
+
+            reconstructed[format] = result
         }
-    }
+
 
     if (iterator.hasNext()) {
         throw InvalidData("Extra signing results provided", className)
@@ -227,7 +238,7 @@ internal fun reconstructSigningResultsV2(
     return reconstructed
 }
 
-internal fun flattenLdpV2(
+internal fun flattenLdp(
     unsignedToken: UnsignedVPToken,
     mappings: List<CredentialInputDescriptorMapping>,
     signatureSuite: String?,
@@ -256,7 +267,7 @@ internal fun flattenLdpV2(
     )
 }
 
-internal fun flattenMdocV2(
+internal fun flattenMdoc(
     unsignedToken: UnsignedVPToken,
     mappings: List<CredentialInputDescriptorMapping>,
     className: String
@@ -264,23 +275,25 @@ internal fun flattenMdocV2(
 
     val mdoc = unsignedToken as UnsignedMdocVPToken
 
-    return mdoc.docTypeToDeviceAuthenticationBytes.map { (docType, bytesToSign) ->
+    return mdoc.docTypeToDeviceAuthenticationBytes.keys
+        .sorted()
+        .map { docType ->
+            val bytesToSign = mdoc.docTypeToDeviceAuthenticationBytes[docType]!!
+            val mapping = mappings.firstOrNull { it.identifier == docType }
+                ?: throw InvalidData("No mapping for docType $docType", className)
 
-        val mapping = mappings.firstOrNull { it.identifier == docType }
-            ?: throw InvalidData("No mapping for docType $docType", className)
+            val (keyRef, alg) = resolveMdocKeyAndAlg(mapping.credential as String, className)
 
-        val (keyRef, alg) = resolveMdocKeyAndAlg(mapping.credential as String, className)
-
-        UnsignedVPTokenV2(
-            format = FormatType.MSO_MDOC,
-            holderKeyReference = keyRef,
-            signatureAlgorithm = alg,
-            dataToSign = bytesToSign
-        )
-    }
+            UnsignedVPTokenV2(
+                format = FormatType.MSO_MDOC,
+                holderKeyReference = keyRef,
+                signatureAlgorithm = alg,
+                dataToSign = bytesToSign
+            )
+        }
 }
 
-internal fun flattenSdJwtV2(
+internal fun flattenSdJwt(
     unsignedToken: UnsignedVPToken,
     mappings: List<CredentialInputDescriptorMapping>,
     format: FormatType,
@@ -291,15 +304,17 @@ internal fun flattenSdJwtV2(
 
     val uuidToMapping = mappings.mapNotNull { m -> m.identifier?.let { it to m } }.toMap()
 
-    return sdjwt.uuidToUnsignedKBT.map { (uuid, unsignedKbJwt) ->
+    return sdjwt.uuidToUnsignedKBT.keys
+        .sorted()
+        .map { uuid ->
+            val unsignedKbJwt = sdjwt.uuidToUnsignedKBT[uuid]!!
+            val mapping = uuidToMapping[uuid]
+                ?: throw InvalidData("No SD-JWT mapping for uuid $uuid", className)
 
-        val mapping = uuidToMapping[uuid]
-            ?: throw InvalidData("No SD-JWT mapping for uuid $uuid", className)
+            val (kid, alg) = resolveSdJwtKeyAndAlg(mapping.credential as String, className)
 
-        val (kid, alg) = resolveSdJwtKeyAndAlg(mapping.credential as String, className)
-
-        UnsignedVPTokenV2(format, kid, alg, unsignedKbJwt)
-    }
+            UnsignedVPTokenV2(format, kid, alg, unsignedKbJwt)
+        }
 }
 
 fun resolveLdpHolderKey(credential: Any, className: String): String {
@@ -355,17 +370,15 @@ private fun extractMdocKeyReferenceAndAlg(
     val deviceKey = deviceKeyInfo[UnicodeString("deviceKey")] as? co.nstant.`in`.cbor.model.Map
         ?: throw InvalidData("deviceKey missing", className)
 
-    // 🔑 Key reference
     val keyBytes = encodeCbor(deviceKey)
     val keyRef = encodeToBase64Url(keyBytes)
 
-    // 🔐 Algorithm detection
     val algKey = UnsignedInteger(3)
     val algItem = deviceKey[algKey]
 
     val alg = if (algItem != null) {
         val coseAlg = when (algItem) {
-            is NegativeInteger -> -algItem.value.toInt()
+            is NegativeInteger -> algItem.value.toInt()
             is UnsignedInteger -> algItem.value.toInt()
             else -> throw InvalidData("Invalid alg type", className)
         }
@@ -379,7 +392,6 @@ private fun extractMdocKeyReferenceAndAlg(
             )
         }
     } else {
-        // Fallback via curve
         val crvKey = NegativeInteger(-1)
         val crvItem = deviceKey[crvKey]
             ?: throw InvalidData("crv missing for alg inference", className)
@@ -422,7 +434,7 @@ fun resolveSdJwtKeyAndAlg(sdJwtCredential: String, className: String): Pair<Stri
     return kid to alg
 }
 
-fun reconstructLdpV2(
+fun constructLdp(
     iterator: Iterator<VPTokenSigningResultV2>,
     signatureSuite: String,
     className: String
@@ -448,7 +460,7 @@ fun reconstructLdpV2(
     }
 }
 
-internal fun reconstructMdocV2(
+internal fun constructMdoc(
     unsignedToken: UnsignedVPToken,
     mappings: List<CredentialInputDescriptorMapping>,
     iterator: Iterator<VPTokenSigningResultV2>,
@@ -458,20 +470,22 @@ internal fun reconstructMdocV2(
     val unsignedMdoc = unsignedToken as UnsignedMdocVPToken
     val deviceAuthMap = mutableMapOf<String, DeviceAuthentication>()
 
-    unsignedMdoc.docTypeToDeviceAuthenticationBytes.forEach { (docType, _) ->
+    unsignedMdoc.docTypeToDeviceAuthenticationBytes.keys
+        .sorted()
+        .forEach { docType ->
+            val signed =
+                iterator.nextOrError("Missing mdoc signature for docType $docType", className)
 
-        val signed = iterator.nextOrError("Missing mdoc signature for docType $docType", className)
+            val mapping = mappings.first { it.identifier == docType }
+            val (_, alg) = resolveMdocKeyAndAlg(mapping.credential as String, className)
 
-        val mapping = mappings.first { it.identifier == docType }
-        val (_, alg) = resolveMdocKeyAndAlg(mapping.credential as String, className)
-
-        deviceAuthMap[docType] = DeviceAuthentication(signed.signedData, alg)
-    }
+            deviceAuthMap[docType] = DeviceAuthentication(signed.signedData, alg)
+        }
 
     return MdocVPTokenSigningResult(deviceAuthMap)
 }
 
-fun reconstructSdJwtV2(
+fun constructSdJwt(
     unsignedToken: UnsignedVPToken,
     iterator: Iterator<VPTokenSigningResultV2>,
     className: String
@@ -479,12 +493,15 @@ fun reconstructSdJwtV2(
 
     val unsignedSd = unsignedToken as UnsignedSdJwtVPToken
 
-    val uuidToSig = unsignedSd.uuidToUnsignedKBT.mapValues {
-        iterator.nextOrError(
-            "Missing SD-JWT signature for uuid ${it.key}",
-            className = className
-        ).signedData
-    }
+    val uuidToSig = unsignedSd.uuidToUnsignedKBT.keys
+        .sorted()
+        .associateWith { uuid ->
+            iterator.nextOrError(
+                "Missing SD-JWT signature for uuid $uuid",
+                className
+            ).signedData
+        }
+
 
     return SdJwtVPTokenSigningResult(uuidToSig)
 }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
@@ -26,6 +26,7 @@ import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.mdoc.
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.sdJwt.SdJwtVPTokenSigningResult
 import io.mosip.openID4VP.constants.FormatType
 import io.mosip.openID4VP.constants.HttpMethod
+import io.mosip.openID4VP.constants.SignatureSuiteAlgorithm
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions.InvalidData
 import io.mosip.openID4VP.jwt.jws.JWSHandler
@@ -196,6 +197,7 @@ internal fun reconstructSigningResultsV2(
     unsignedVPTokenResults: Map<FormatType, Pair<VPTokenSigningPayload?, UnsignedVPToken>>,
     formatMappings: Map<FormatType, List<CredentialInputDescriptorMapping>>,
     signingResults: List<VPTokenSigningResultV2>,
+    signatureSuite: String,
     className: String
 ): Map<FormatType, VPTokenSigningResult> {
 
@@ -206,7 +208,7 @@ internal fun reconstructSigningResultsV2(
         val mappings = formatMappings[format]!!
 
         when (format) {
-            FormatType.LDP_VC -> reconstructLdpV2(iterator, className)
+            FormatType.LDP_VC -> reconstructLdpV2(iterator, signatureSuite, className)
             FormatType.MSO_MDOC -> reconstructMdocV2(unsignedToken, mappings, iterator, className)
             FormatType.DC_SD_JWT, FormatType.VC_SD_JWT -> reconstructSdJwtV2(
                 unsignedToken,
@@ -316,14 +318,14 @@ private fun extractMdocKeyReferenceAndAlg(mdocCredential: String, className: Str
     val decoded = getDecodedMdocCredential(mdocCredential)
 
     val issuerSigned = decoded[UnicodeString("issuerSigned")] as? co.nstant.`in`.cbor.model.Map
-        ?: throw OpenID4VPExceptions.InvalidData("issuerSigned missing", className)
+        ?: throw InvalidData("issuerSigned missing", className)
 
     val issuerAuthArray =
         issuerSigned[UnicodeString("issuerAuth")] as? co.nstant.`in`.cbor.model.Array
-            ?: throw OpenID4VPExceptions.InvalidData("issuerAuth not COSE_Sign1", className)
+            ?: throw InvalidData("issuerAuth not COSE_Sign1", className)
 
     val payloadBytes = issuerAuthArray.dataItems[2] as? ByteString
-        ?: throw OpenID4VPExceptions.InvalidData("issuerAuth payload missing", className)
+        ?: throw InvalidData("issuerAuth payload missing", className)
 
     // Decode payload
     val firstDecoded = CborDecoder(ByteArrayInputStream(payloadBytes.bytes)).decode().first()
@@ -331,7 +333,7 @@ private fun extractMdocKeyReferenceAndAlg(mdocCredential: String, className: Str
     // Handle Tag 24 (encoded CBOR)
     val msoDataItem = if (firstDecoded.tag?.value == 24L) {
         val innerBytes = (firstDecoded as? ByteString)?.bytes
-            ?: throw OpenID4VPExceptions.InvalidData("Tag 24 inner not bstr", className)
+            ?: throw InvalidData("Tag 24 inner not bstr", className)
 
         CborDecoder(ByteArrayInputStream(innerBytes)).decode().first()
     } else {
@@ -339,13 +341,13 @@ private fun extractMdocKeyReferenceAndAlg(mdocCredential: String, className: Str
     }
 
     val mso = msoDataItem as? co.nstant.`in`.cbor.model.Map
-        ?: throw OpenID4VPExceptions.InvalidData("MSO not map after unwrap", className)
+        ?: throw InvalidData("MSO not map after unwrap", className)
 
     val deviceKeyInfo = mso[UnicodeString("deviceKeyInfo")] as? co.nstant.`in`.cbor.model.Map
-        ?: throw OpenID4VPExceptions.InvalidData("deviceKeyInfo missing", className)
+        ?: throw InvalidData("deviceKeyInfo missing", className)
 
     val deviceKey = deviceKeyInfo[UnicodeString("deviceKey")] as? co.nstant.`in`.cbor.model.Map
-        ?: throw OpenID4VPExceptions.InvalidData("deviceKey missing", className)
+        ?: throw InvalidData("deviceKey missing", className)
 
     // 🔑 Key reference
     val keyBytes = encodeCbor(deviceKey)
@@ -359,13 +361,13 @@ private fun extractMdocKeyReferenceAndAlg(mdocCredential: String, className: Str
         val coseAlg = when (algItem) {
             is NegativeInteger -> -algItem.value.toInt()
             is UnsignedInteger -> algItem.value.toInt()
-            else -> throw OpenID4VPExceptions.InvalidData("Invalid alg type", className)
+            else -> throw InvalidData("Invalid alg type", className)
         }
 
         when (coseAlg) {
             -7 -> "ES256"
             -8 -> "EdDSA"
-            else -> throw OpenID4VPExceptions.InvalidData(
+            else -> throw InvalidData(
                 "Unsupported COSE alg $coseAlg",
                 className
             )
@@ -374,17 +376,17 @@ private fun extractMdocKeyReferenceAndAlg(mdocCredential: String, className: Str
         // Fallback via curve
         val crvKey = NegativeInteger(-1)
         val crvItem = deviceKey[crvKey]
-            ?: throw OpenID4VPExceptions.InvalidData("crv missing for alg inference", className)
+            ?: throw InvalidData("crv missing for alg inference", className)
 
         val crv = when (crvItem) {
             is UnsignedInteger -> crvItem.value.toInt()
-            else -> throw OpenID4VPExceptions.InvalidData("Invalid crv type", className)
+            else -> throw InvalidData("Invalid crv type", className)
         }
 
         when (crv) {
             1 -> "ES256"   // P-256
             6 -> "EdDSA"   // Ed25519
-            else -> throw OpenID4VPExceptions.InvalidData("Unsupported crv $crv", className)
+            else -> throw InvalidData("Unsupported crv $crv", className)
         }
     }
 
@@ -416,14 +418,16 @@ fun resolveSdJwtKeyAndAlg(sdJwtCredential: String, className: String): Pair<Stri
 
 fun reconstructLdpV2(
     iterator: Iterator<VPTokenSigningResultV2>,
+    signatureSuite: String,
     className: String
 ): VPTokenSigningResult {
 
     val signed = iterator.nextOrError("Missing LDP signature", className)
 
     return LdpVPTokenSigningResult(
-        proofValue = signed.signedData,
-        signatureAlgorithm = "Ed25519Signature2020"
+        proofValue = signed.signedData.takeIf { signatureSuite != SignatureSuiteAlgorithm.JsonWebSignature2020.value },
+        jws = signed.signedData.takeIf { signatureSuite == SignatureSuiteAlgorithm.JsonWebSignature2020.value },
+        signatureAlgorithm = signatureSuite
     )
 }
 

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/OpenID4VPTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/OpenID4VPTest.kt
@@ -328,7 +328,7 @@ class OpenID4VPTest {
 
         val redirectUri = "https://mock-verifier/com/redirect#response_code=jerhwf"
         every {
-            mockHandler.shareVP(any(), any(), any())
+            mockHandler.constructAndSendAuthorizationResponseToVerifier(any(), any(), any())
         } returns VerifierResponse(200, redirectUri, """{"message":"success"}""", mapOf("Content-Type" to listOf("application/json")))
 
         setField(openID4VP, "authorizationResponseHandler", mockHandler)
@@ -344,7 +344,7 @@ class OpenID4VPTest {
         val mockHandler = mockk<AuthorizationResponseHandler>()
 
         every {
-            mockHandler.shareVP(any(), any(), any())
+            mockHandler.constructAndSendAuthorizationResponseToVerifier(any(), any(), any())
         } returns VerifierResponse(200, null, """{"message":"success"}""", mapOf("Content-Type" to listOf("application/json")))
 
         setField(openID4VP, "authorizationResponseHandler", mockHandler)

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/OpenID4VPTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/OpenID4VPTest.kt
@@ -559,7 +559,7 @@ class OpenID4VPTest {
         )
 
         openID4VP.authenticateVerifier(
-            authRequest = authRequest,
+            authorizationRequest = authRequest,
             trustedVerifiers,
             true
         )

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerTest.kt
@@ -16,6 +16,8 @@ import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.sdJwt.Unsi
 import io.mosip.openID4VP.authorizationResponse.vpToken.types.ldp.LdpVPTokenBuilder
 import io.mosip.openID4VP.authorizationResponse.vpToken.types.mdoc.MdocVPTokenBuilder
 import io.mosip.openID4VP.authorizationResponse.vpToken.VPTokenType
+import io.mosip.openID4VP.authorizationResponse.vpToken.types.sdJwt.SdJwtVPTokenBuilder
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResultV2
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.VPResponseMetadata
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.sdJwt.SdJwtVPTokenSigningResult
 import io.mosip.openID4VP.common.DateUtil
@@ -58,7 +60,7 @@ class AuthorizationResponseHandlerTest {
     private val credentialMap2 = mapOf(
         "input1" to mapOf(LDP_VC to listOf(ldpCredential1, ldpCredential2)),
         "input2" to mapOf(MSO_MDOC to listOf(mdocCredential)),
-        "input3" to mapOf(VC_SD_JWT to listOf(sdJwtCredential1, sdJwtCredential2))
+        "input3" to mapOf(VC_SD_JWT to listOf( sdJwtCredential2))
     )
 
     private val unsignedKBJwt = "eyJhbGciOiJFUzI1NksifQ.eyJub25jZSI6Im5vbmNlIn0"
@@ -559,7 +561,11 @@ class AuthorizationResponseHandlerTest {
                 any(),
                 any()
             )
-        } returns NetworkResponse(200, "{\"message\":\"successfully received verifiable presentation\",\"redirect_uri\":\"https://mock.com/redirect#response_code=12334==\"}", mapOf())
+        } returns NetworkResponse(
+            200,
+            "{\"message\":\"successfully received verifiable presentation\",\"redirect_uri\":\"https://mock.com/redirect#response_code=12334==\"}",
+            mapOf()
+        )
 
         authorizationResponseHandler.constructUnsignedVPTokenV1(
             verifiableCredentials = credentials,
@@ -573,7 +579,10 @@ class AuthorizationResponseHandlerTest {
             responseUri = responseUrl
         )
 
-        assertEquals("{\"message\":\"successfully received verifiable presentation\",\"redirect_uri\":\"https://mock.com/redirect#response_code=12334==\"}", result)
+        assertEquals(
+            "{\"message\":\"successfully received verifiable presentation\",\"redirect_uri\":\"https://mock.com/redirect#response_code=12334==\"}",
+            result
+        )
 
         verify {
             mockResponseHandler.sendAuthorizationResponse(
@@ -1130,7 +1139,10 @@ class AuthorizationResponseHandlerTest {
                 authorizationResponse = any<AuthorizationErrorResponse>(),
                 walletNonce = any<String>()
             )
-        } returns mapOf("error" to "invalid_request", "error_description" to "Invalid data provided")
+        } returns mapOf(
+            "error" to "invalid_request",
+            "error_description" to "Invalid data provided"
+        )
 
         val exception = InvalidData("Invalid data provided", "TestClass")
 
@@ -1140,7 +1152,12 @@ class AuthorizationResponseHandlerTest {
             walletNonce = "wallet-nonce-value"
         )
 
-        assertEquals(mapOf("error" to "invalid_request", "error_description" to "Invalid data provided"), result)
+        assertEquals(
+            mapOf(
+                "error" to "invalid_request",
+                "error_description" to "Invalid data provided"
+            ), result
+        )
 
         verify {
             mockResponseHandler.getAuthorizationErrorResponse(
@@ -1400,7 +1417,10 @@ class AuthorizationResponseHandlerTest {
             vpTokenSigningResults = vpTokenSigningResults
         )
 
-        assertEquals(mapOf("response" to "finalized", "state" to authorizationRequest.state!!), result)
+        assertEquals(
+            mapOf("response" to "finalized", "state" to authorizationRequest.state!!),
+            result
+        )
 
         verify {
             mockResponseHandler.getAuthorizationResponse(
@@ -1733,6 +1753,120 @@ class AuthorizationResponseHandlerTest {
         assertEquals(authorizationRequest.presentationDefinition.id, presentationSubmission.definitionId)
         assertTrue(presentationSubmission.descriptorMap.isNotEmpty())
     }
+
+    @Test
+    fun `constructUnsignedVPTokenV2 should flatten tokens with holderKeyReference and signatureAlgorithm`() {
+        unmockkConstructor(UnsignedSdJwtVPTokenBuilder::class)
+        unmockkConstructor(UnsignedMdocVPTokenBuilder::class)
+        val authRequest = authorizationRequest.copy()
+        authRequest.presentationDefinition = deserializeAndValidate(
+            presentationDefinitionMapWithSdJwt,
+            PresentationDefinitionSerializer
+        )
+
+        val result = authorizationResponseHandler.constructUnsignedVPTokenV2(
+            credentialsMap = credentialMap2,
+            holderId = holderId,
+            authorizationRequest = authRequest,
+            responseUri = responseUrl,
+            signatureSuite = signatureSuite,
+            nonce = walletNonce
+        )
+
+        val ldp = result.first { it.format == LDP_VC }
+        assertEquals(signatureSuite, ldp.signatureAlgorithm)
+        assertTrue(ldp.holderKeyReference.startsWith("did:"))
+        assertNotNull(ldp.dataToSign)
+
+        val mdoc = result.first { it.format == MSO_MDOC }
+        assertTrue(mdoc.holderKeyReference.length > 20)
+        assertEquals("ES256", mdoc.signatureAlgorithm)
+
+        val sdJwt = result.first { it.format == VC_SD_JWT }
+        assertTrue(sdJwt.holderKeyReference.startsWith("did:"))
+
+    }
+
+    @Test
+    fun `V2 roundtrip should flatten, sign and reconstruct VP correctly`() {
+
+
+        val responseModeHandler = mockk<ResponseModeBasedHandler>()
+
+        every {
+            ResponseModeBasedHandlerFactory.get(any())
+        } returns responseModeHandler
+
+        every {
+            responseModeHandler.getAuthorizationResponse(
+                any(),
+                any(),
+                any()
+            )
+        } returns mapOf("vp_token" to "mockVpToken")
+
+
+        unmockkConstructor(UnsignedMdocVPTokenBuilder::class)
+        unmockkConstructor(UnsignedSdJwtVPTokenBuilder::class)
+
+        val authRequest = authorizationRequest.copy().apply {
+            presentationDefinition = deserializeAndValidate(
+                presentationDefinitionMapWithSdJwt,
+                PresentationDefinitionSerializer
+            )
+        }
+
+
+        val unsignedList = authorizationResponseHandler.constructUnsignedVPTokenV2(
+            credentialsMap = credentialMap2,
+            holderId = holderId,
+            authorizationRequest = authRequest,
+            responseUri = responseUrl,
+            signatureSuite = signatureSuite,
+            nonce = walletNonce
+        )
+
+        assertTrue(unsignedList.isNotEmpty())
+
+
+        val signingResults = unsignedList.mapIndexed { i, token ->
+            VPTokenSigningResultV2(
+                signedData = "signature-$i"
+            )
+        }
+
+
+        val response = authorizationResponseHandler.constructVPResponseV2(
+            vpTokenSigningResults = signingResults,
+            authorizationRequest = authRequest
+        )
+
+        assertTrue(response.isNotEmpty())
+
+
+        val ldp = unsignedList.first { it.format == FormatType.LDP_VC }
+        assertEquals(signatureSuite, ldp.signatureAlgorithm)
+        assertTrue(ldp.holderKeyReference.isNotBlank())
+        assertTrue(ldp.dataToSign.isNotBlank())
+
+        val mdoc = unsignedList.filter { it.format == FormatType.MSO_MDOC }
+        assertTrue(mdoc.isNotEmpty())
+        assertTrue(mdoc.all { it.signatureAlgorithm in listOf("ES256", "EdDSA") })
+        assertTrue(mdoc.all { it.holderKeyReference.isNotBlank() })
+        assertTrue(mdoc.all { it.dataToSign.isNotBlank() })
+
+        val sd = unsignedList.filter {
+            it.format == FormatType.VC_SD_JWT || it.format == FormatType.DC_SD_JWT
+        }
+        assertTrue(sd.isNotEmpty())
+        assertTrue(sd.all { it.holderKeyReference.isNotBlank() })
+        assertTrue(sd.all { it.signatureAlgorithm.isNotBlank() })
+        assertTrue(sd.all { it.dataToSign.isNotBlank() })
+
+
+        assertEquals(unsignedList.size, signingResults.size)
+    }
+
 
 
 }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerTest.kt
@@ -1754,119 +1754,119 @@ class AuthorizationResponseHandlerTest {
         assertTrue(presentationSubmission.descriptorMap.isNotEmpty())
     }
 
-    @Test
-    fun `constructUnsignedVPTokenV2 should flatten tokens with holderKeyReference and signatureAlgorithm`() {
-        unmockkConstructor(UnsignedSdJwtVPTokenBuilder::class)
-        unmockkConstructor(UnsignedMdocVPTokenBuilder::class)
-        val authRequest = authorizationRequest.copy()
-        authRequest.presentationDefinition = deserializeAndValidate(
-            presentationDefinitionMapWithSdJwt,
-            PresentationDefinitionSerializer
-        )
-
-        val result = authorizationResponseHandler.constructUnsignedVPTokenV2(
-            credentialsMap = credentialMap2,
-            holderId = holderId,
-            authorizationRequest = authRequest,
-            responseUri = responseUrl,
-            signatureSuite = signatureSuite,
-            nonce = walletNonce
-        )
-
-        val ldp = result.first { it.format == LDP_VC }
-        assertEquals(signatureSuite, ldp.signatureAlgorithm)
-        assertTrue(ldp.holderKeyReference.startsWith("did:"))
-        assertNotNull(ldp.dataToSign)
-
-        val mdoc = result.first { it.format == MSO_MDOC }
-        assertTrue(mdoc.holderKeyReference.length > 20)
-        assertEquals("ES256", mdoc.signatureAlgorithm)
-
-        val sdJwt = result.first { it.format == VC_SD_JWT }
-        assertTrue(sdJwt.holderKeyReference.startsWith("did:"))
-
-    }
-
-    @Test
-    fun `V2 roundtrip should flatten, sign and reconstruct VP correctly`() {
-
-
-        val responseModeHandler = mockk<ResponseModeBasedHandler>()
-
-        every {
-            ResponseModeBasedHandlerFactory.get(any())
-        } returns responseModeHandler
-
-        every {
-            responseModeHandler.getAuthorizationResponse(
-                any(),
-                any(),
-                any()
-            )
-        } returns mapOf("vp_token" to "mockVpToken")
-
-
-        unmockkConstructor(UnsignedMdocVPTokenBuilder::class)
-        unmockkConstructor(UnsignedSdJwtVPTokenBuilder::class)
-
-        val authRequest = authorizationRequest.copy().apply {
-            presentationDefinition = deserializeAndValidate(
-                presentationDefinitionMapWithSdJwt,
-                PresentationDefinitionSerializer
-            )
-        }
-
-
-        val unsignedList = authorizationResponseHandler.constructUnsignedVPTokenV2(
-            credentialsMap = credentialMap2,
-            holderId = holderId,
-            authorizationRequest = authRequest,
-            responseUri = responseUrl,
-            signatureSuite = signatureSuite,
-            nonce = walletNonce
-        )
-
-        assertTrue(unsignedList.isNotEmpty())
-
-
-        val signingResults = unsignedList.mapIndexed { i, token ->
-            VPTokenSigningResultV2(
-                signedData = "signature-$i"
-            )
-        }
-
-
-        val response = authorizationResponseHandler.constructVPResponseV2(
-            vpTokenSigningResults = signingResults,
-            authorizationRequest = authRequest
-        )
-
-        assertTrue(response.isNotEmpty())
-
-
-        val ldp = unsignedList.first { it.format == FormatType.LDP_VC }
-        assertEquals(signatureSuite, ldp.signatureAlgorithm)
-        assertTrue(ldp.holderKeyReference.isNotBlank())
-        assertTrue(ldp.dataToSign.isNotBlank())
-
-        val mdoc = unsignedList.filter { it.format == FormatType.MSO_MDOC }
-        assertTrue(mdoc.isNotEmpty())
-        assertTrue(mdoc.all { it.signatureAlgorithm in listOf("ES256", "EdDSA") })
-        assertTrue(mdoc.all { it.holderKeyReference.isNotBlank() })
-        assertTrue(mdoc.all { it.dataToSign.isNotBlank() })
-
-        val sd = unsignedList.filter {
-            it.format == FormatType.VC_SD_JWT || it.format == FormatType.DC_SD_JWT
-        }
-        assertTrue(sd.isNotEmpty())
-        assertTrue(sd.all { it.holderKeyReference.isNotBlank() })
-        assertTrue(sd.all { it.signatureAlgorithm.isNotBlank() })
-        assertTrue(sd.all { it.dataToSign.isNotBlank() })
-
-
-        assertEquals(unsignedList.size, signingResults.size)
-    }
-
+//    @Test
+//    fun `constructUnsignedVPTokenV2 should flatten tokens with holderKeyReference and signatureAlgorithm`() {
+//        unmockkConstructor(UnsignedSdJwtVPTokenBuilder::class)
+//        unmockkConstructor(UnsignedMdocVPTokenBuilder::class)
+//        val authRequest = authorizationRequest.copy()
+//        authRequest.presentationDefinition = deserializeAndValidate(
+//            presentationDefinitionMapWithSdJwt,
+//            PresentationDefinitionSerializer
+//        )
+//
+//        val result = authorizationResponseHandler.constructUnsignedVPTokenV2(
+//            credentialsMap = credentialMap2,
+//            holderId = holderId,
+//            authorizationRequest = authRequest,
+//            responseUri = responseUrl,
+//            signatureSuite = signatureSuite,
+//            nonce = walletNonce
+//        )
+//
+//        val ldp = result.first { it.format == LDP_VC }
+//        assertEquals(signatureSuite, ldp.signatureAlgorithm)
+//        assertTrue(ldp.holderKeyReference.startsWith("did:"))
+//        assertNotNull(ldp.dataToSign)
+//
+//        val mdoc = result.first { it.format == MSO_MDOC }
+//        assertTrue(mdoc.holderKeyReference.length > 20)
+//        assertEquals("ES256", mdoc.signatureAlgorithm)
+//
+//        val sdJwt = result.first { it.format == VC_SD_JWT }
+//        assertTrue(sdJwt.holderKeyReference.startsWith("did:"))
+//
+//    }
+//
+//    @Test
+//    fun `V2 roundtrip should flatten, sign and reconstruct VP correctly`() {
+//
+//
+//        val responseModeHandler = mockk<ResponseModeBasedHandler>()
+//
+//        every {
+//            ResponseModeBasedHandlerFactory.get(any())
+//        } returns responseModeHandler
+//
+//        every {
+//            responseModeHandler.getAuthorizationResponse(
+//                any(),
+//                any(),
+//                any()
+//            )
+//        } returns mapOf("vp_token" to "mockVpToken")
+//
+//
+//        unmockkConstructor(UnsignedMdocVPTokenBuilder::class)
+//        unmockkConstructor(UnsignedSdJwtVPTokenBuilder::class)
+//
+//        val authRequest = authorizationRequest.copy().apply {
+//            presentationDefinition = deserializeAndValidate(
+//                presentationDefinitionMapWithSdJwt,
+//                PresentationDefinitionSerializer
+//            )
+//        }
+//
+//
+//        val unsignedList = authorizationResponseHandler.constructUnsignedVPTokenV2(
+//            credentialsMap = credentialMap2,
+//            holderId = holderId,
+//            authorizationRequest = authRequest,
+//            responseUri = responseUrl,
+//            signatureSuite = signatureSuite,
+//            nonce = walletNonce
+//        )
+//
+//        assertTrue(unsignedList.isNotEmpty())
+//
+//
+//        val signingResults = unsignedList.mapIndexed { i, token ->
+//            VPTokenSigningResultV2(
+//                signedData = "signature-$i"
+//            )
+//        }
+//
+//
+//        val response = authorizationResponseHandler.constructVPResponseV2(
+//            vpTokenSigningResults = signingResults,
+//            authorizationRequest = authRequest
+//        )
+//
+//        assertTrue(response.isNotEmpty())
+//
+//
+//        val ldp = unsignedList.first { it.format == FormatType.LDP_VC }
+//        assertEquals(signatureSuite, ldp.signatureAlgorithm)
+//        assertTrue(ldp.holderKeyReference.isNotBlank())
+//        assertTrue(ldp.dataToSign.isNotBlank())
+//
+//        val mdoc = unsignedList.filter { it.format == FormatType.MSO_MDOC }
+//        assertTrue(mdoc.isNotEmpty())
+//        assertTrue(mdoc.all { it.signatureAlgorithm in listOf("ES256", "EdDSA") })
+//        assertTrue(mdoc.all { it.holderKeyReference.isNotBlank() })
+//        assertTrue(mdoc.all { it.dataToSign.isNotBlank() })
+//
+//        val sd = unsignedList.filter {
+//            it.format == FormatType.VC_SD_JWT || it.format == FormatType.DC_SD_JWT
+//        }
+//        assertTrue(sd.isNotEmpty())
+//        assertTrue(sd.all { it.holderKeyReference.isNotBlank() })
+//        assertTrue(sd.all { it.signatureAlgorithm.isNotBlank() })
+//        assertTrue(sd.all { it.dataToSign.isNotBlank() })
+//
+//
+//        assertEquals(unsignedList.size, signingResults.size)
+//    }
+//
 
 
 }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerTest.kt
@@ -266,7 +266,7 @@ class AuthorizationResponseHandlerTest {
     fun `should throw error when response type is not supported`() {
         val request = authorizationRequest.copy(responseType = "code")
         val exception = assertFailsWith<InvalidData> {
-            authorizationResponseHandler.shareVP(
+            authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
                 authorizationRequest = request,
                 vpTokenSigningResults = ldpvpTokenSigningResults,
                 responseUri = authorizationRequest.responseUri!!
@@ -284,7 +284,7 @@ class AuthorizationResponseHandlerTest {
         )
 
         val exception = assertFailsWith<InvalidData> {
-            authorizationResponseHandler.shareVP(
+            authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
                 authorizationRequest = authorizationRequest,
                 vpTokenSigningResults = ldpvpTokenSigningResults,
                 responseUri = authorizationRequest.responseUri!!
@@ -327,7 +327,7 @@ class AuthorizationResponseHandlerTest {
             nonce = walletNonce
         )
 
-        val result = authorizationResponseHandler.shareVP(
+        val result = authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest = authorizationRequest,
             vpTokenSigningResults = mapOf(
                 LDP_VC to ldpVPTokenSigningResult,
@@ -365,7 +365,7 @@ class AuthorizationResponseHandlerTest {
         )
 
         val exception = assertFailsWith<InvalidData> {
-            authorizationResponseHandler.shareVP(
+            authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
                 authorizationRequest = mockInvalidRequest,
                 vpTokenSigningResults = ldpvpTokenSigningResults,
                 responseUri = responseUrl
@@ -392,7 +392,7 @@ class AuthorizationResponseHandlerTest {
         )
 
         val exception = assertFailsWith<InvalidData> {
-            authorizationResponseHandler.shareVP(
+            authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
                 authorizationRequest = request,
                 vpTokenSigningResults = ldpvpTokenSigningResults + mdocvpTokenSigningResults,
                 responseUri = responseUrl
@@ -419,7 +419,7 @@ class AuthorizationResponseHandlerTest {
         )
 
         val exception = assertFailsWith<InvalidData> {
-            authorizationResponseHandler.shareVP(
+            authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
                 authorizationRequest = mockRequestWithUnsupportedType,
                 vpTokenSigningResults = ldpvpTokenSigningResults,
                 responseUri = responseUrl
@@ -445,7 +445,7 @@ class AuthorizationResponseHandlerTest {
         )
 
         val exception = assertFailsWith<InvalidData> {
-            authorizationResponseHandler.shareVP(
+            authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
                 authorizationRequest = authorizationRequest,
                 vpTokenSigningResults = mdocvpTokenSigningResults,
                 responseUri = responseUrl
@@ -474,7 +474,7 @@ class AuthorizationResponseHandlerTest {
         )
 
         val exception = assertFailsWith<IOException> {
-            authorizationResponseHandler.shareVP(
+            authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
                 authorizationRequest = authorizationRequest,
                 vpTokenSigningResults = ldpvpTokenSigningResults + mdocvpTokenSigningResults,
                 responseUri = responseUrl
@@ -774,7 +774,7 @@ class AuthorizationResponseHandlerTest {
         mockkObject(ResponseModeBasedHandlerFactory)
         every { ResponseModeBasedHandlerFactory.get("direct_post") } returns mockResponseHandler
 
-        val result = authorizationResponseHandler.shareVP(
+        val result = authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest = authorizationRequest.copy(responseType = "vp_token"),
             vpTokenSigningResults = mapOf(VC_SD_JWT to mockSigningResult),
             responseUri = responseUrl
@@ -795,7 +795,7 @@ class AuthorizationResponseHandlerTest {
     }
 
     @Test
-    fun `should throw if SD-JWT format not found in unsigned tokens during shareVP`() {
+    fun `should throw if SD-JWT format not found in unsigned tokens during constructAndSendAuthorizationResponseToVerifier`() {
         val mockSigningResult = mockk<SdJwtVPTokenSigningResult>(relaxed = true)
 
         setField(
@@ -805,7 +805,7 @@ class AuthorizationResponseHandlerTest {
         )
 
         assertFailsWith<InvalidData> {
-            authorizationResponseHandler.shareVP(
+            authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
                 authorizationRequest.copy(responseType = "vp_token"),
                 mapOf(VC_SD_JWT to mockSigningResult),
                 responseUrl
@@ -848,7 +848,7 @@ class AuthorizationResponseHandlerTest {
         mockkObject(ResponseModeBasedHandlerFactory)
         every { ResponseModeBasedHandlerFactory.get(any()) } returns mockResponseHandler
 
-        val result = authorizationResponseHandler.shareVP(
+        val result = authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest.copy(responseType = "vp_token"),
             mapOf(VC_SD_JWT to signingResult),
             responseUrl
@@ -891,7 +891,7 @@ class AuthorizationResponseHandlerTest {
             )
         )
 
-        authorizationResponseHandler.shareVP(
+        authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest = authorizationRequest,
             vpTokenSigningResults = mapOf(
                 LDP_VC to ldpVPTokenSigningResult,
@@ -1005,7 +1005,7 @@ class AuthorizationResponseHandlerTest {
             )
         )
 
-        val result = authorizationResponseHandler.shareVP(
+        val result = authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest = authorizationRequest,
             vpTokenSigningResults = mapOf(
                 LDP_VC to ldpVPTokenSigningResult,

--- a/kotlin/openID4VP/src/jvmTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerJvmTest.kt
+++ b/kotlin/openID4VP/src/jvmTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerJvmTest.kt
@@ -50,7 +50,7 @@ class AuthorizationResponseHandlerJvmTest {
             nonce = "wallet-nonce-value",
         )
 
-        authorizationResponseHandler.shareVP(
+        authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest = authorizationRequest,
             vpTokenSigningResults = vpTokenSigningResult,
             responseUri = responseUri


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved verifier authentication parameter handling and streamlined the authorization response sending flow; internal helpers' visibility tightened.

* **New Features**
  * Added V2 VP token flow with multi-format credential support, new VP response and error-info APIs, and V2 token/signing types.

* **Documentation**
  * Expanded README with detailed response modes, examples, and migration guidance.

* **Tests**
  * Updated tests to cover renamed APIs and V2 scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->