### PR TITLE
feat(openid4vp): Handle Unrecognized Client Identifier Prefix in OpenID4VP

### DIFF
--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestUtils.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestUtils.kt
@@ -86,9 +86,13 @@ fun extractClientIdScheme(authorizationRequestParameters: Map<String, Any>): Str
     val components = clientId.split(":", limit = 2)
 
     return if (components.size > 1) {
-        components[0]
+        val extractedPrefix = components[0]
+        if (ClientIdScheme.fromValue(extractedPrefix) != null) {
+            extractedPrefix
+        } else {
+            PRE_REGISTERED.value
+        }
     } else {
-        // Fallback client_id_scheme pre-registered; pre-registered clients MUST NOT contain a : character in their Client Identifier
         PRE_REGISTERED.value
     }
 }
@@ -101,12 +105,14 @@ fun extractClientIdentifier(authorizationRequestParameters: Map<String, Any>): S
     val clientId = getStringValue(authorizationRequestParameters, CLIENT_ID.value)!!
     val components = clientId.split(":", limit = 2)
     return if (components.size > 1) {
-        val clientIdScheme = components[0]
-        // DID client ID scheme will have the client id itself with did prefix, example - did:example:123#1. So there will not be additional prefix stating client_id_scheme
-        if (clientIdScheme == ClientIdScheme.DID.value) {
-            clientId
-        } else {
-            components[1]
+        when (ClientIdScheme.fromValue(components[0])) {
+            // DID client_id is already self-descriptive, e.g. did:example:123#1.
+            ClientIdScheme.DID -> clientId
+            ClientIdScheme.REDIRECT_URI,
+            ClientIdScheme.PRE_REGISTERED -> components[1]
+
+            // Unrecognized prefix is treated as a full pre-registered client_id.
+            null -> clientId
         }
     } else {
         // client_id_scheme is optional (Fallback client_id_scheme - pre-registered) i.e., a : character is not present in the Client Identifier

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestUtils.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestUtils.kt
@@ -106,12 +106,10 @@ fun extractClientIdentifier(authorizationRequestParameters: Map<String, Any>): S
     val components = clientId.split(":", limit = 2)
     return if (components.size > 1) {
         when (ClientIdScheme.fromValue(components[0])) {
-            // DID client_id is already self-descriptive, e.g. did:example:123#1.
+            // DID client ID scheme will have the client id itself with did prefix, example - did:example:123#1. So there will not be additional prefix stating client_id_scheme
             ClientIdScheme.DID -> clientId
             ClientIdScheme.REDIRECT_URI,
             ClientIdScheme.PRE_REGISTERED -> components[1]
-
-            // Unrecognized prefix is treated as a full pre-registered client_id.
             null -> clientId
         }
     } else {

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestUtils.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestUtils.kt
@@ -106,14 +106,13 @@ fun extractClientIdentifier(authorizationRequestParameters: Map<String, Any>): S
     val components = clientId.split(":", limit = 2)
     return if (components.size > 1) {
         when (ClientIdScheme.fromValue(components[0])) {
-            // DID client ID scheme will have the client id itself with did prefix, example - did:example:123#1. So there will not be additional prefix stating client_id_scheme
             ClientIdScheme.DID -> clientId
-            ClientIdScheme.REDIRECT_URI,
-            ClientIdScheme.PRE_REGISTERED -> components[1]
+            ClientIdScheme.REDIRECT_URI -> components[1]
+            // Pre-registered and unrecognized prefixes return the full client_id
+            ClientIdScheme.PRE_REGISTERED,
             null -> clientId
         }
     } else {
-        // client_id_scheme is optional (Fallback client_id_scheme - pre-registered) i.e., a : character is not present in the Client Identifier
         clientId
     }
 }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
@@ -289,6 +289,7 @@ class AuthorizationRequestTest {
             openID4VP.authenticateVerifier(encodedAuthorizationRequest, trustedVerifiers, shouldValidateClient)
         }
 
+        assertEquals(OpenID4VPErrorCodes.INVALID_CLIENT, exception.errorCode)
         assertEquals("Verifier is not trusted by the wallet", exception.message)
     }
 

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
@@ -725,42 +725,6 @@ class AuthorizationRequestTest {
     }
 
     @Test
-    fun `extractClientIdScheme should return pre-registered when client_id_scheme is explicitly set`() {
-        val params = mapOf<String, Any>(CLIENT_ID.value to "mock-client", CLIENT_ID_SCHEME.value to PRE_REGISTERED.value)
-        assertEquals(PRE_REGISTERED.value, extractClientIdScheme(params))
-    }
-
-    @Test
-    fun `extractClientIdScheme should return did when client_id starts with did prefix`() {
-        val params = mapOf<String, Any>(CLIENT_ID.value to "did:web:example.com:verifier")
-        assertEquals(ClientIdScheme.DID.value, extractClientIdScheme(params))
-    }
-
-    @Test
-    fun `extractClientIdScheme should return redirect_uri when client_id starts with redirect_uri prefix`() {
-        val params = mapOf<String, Any>(CLIENT_ID.value to "redirect_uri:https://verifier.com/callback")
-        assertEquals(ClientIdScheme.REDIRECT_URI.value, extractClientIdScheme(params))
-    }
-
-    @Test
-    fun `extractClientIdScheme should return pre-registered when client_id has unrecognized prefix`() {
-        val params = mapOf<String, Any>(CLIENT_ID.value to "https://verifier.com")
-        assertEquals(PRE_REGISTERED.value, extractClientIdScheme(params))
-    }
-
-    @Test
-    fun `extractClientIdScheme should return pre-registered when client_id has no colon`() {
-        val params = mapOf<String, Any>(CLIENT_ID.value to "govt-verifier")
-        assertEquals(PRE_REGISTERED.value, extractClientIdScheme(params))
-    }
-
-    @Test
-    fun `extractClientIdScheme should return pre-registered for foo prefix`() {
-        val params = mapOf<String, Any>(CLIENT_ID.value to "foo:bar")
-        assertEquals(PRE_REGISTERED.value, extractClientIdScheme(params))
-    }
-
-    @Test
     fun `should treat client_id with URL colon as pre-registered and return full client_id`() {
         val clientIdWithUrlColon = "https://verifier.com"
         val trustedVerifiers = listOf(

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
@@ -196,8 +196,11 @@ class AuthorizationRequestTest {
                     encodedAuthorizationRequest, trustedVerifiers, shouldValidateClient
                 )
             }
-        assertEquals(OpenID4VPErrorCodes.INVALID_CLIENT, actualException.errorCode)
-        assertEquals(expectedExceptionMessage, actualException.message)
+        assertOpenId4VPException(
+            actualException,
+            expectedExceptionMessage,
+            expectedErrorCode = OpenID4VPErrorCodes.INVALID_CLIENT,
+        )
     }
 
     @Test
@@ -289,8 +292,11 @@ class AuthorizationRequestTest {
             openID4VP.authenticateVerifier(encodedAuthorizationRequest, trustedVerifiers, shouldValidateClient)
         }
 
-        assertEquals(OpenID4VPErrorCodes.INVALID_CLIENT, exception.errorCode)
-        assertEquals("Verifier is not trusted by the wallet", exception.message)
+        assertOpenId4VPException(
+            exception,
+            "Verifier is not trusted by the wallet",
+            expectedErrorCode = OpenID4VPErrorCodes.INVALID_CLIENT,
+        )
     }
 
     @Test
@@ -716,5 +722,92 @@ class AuthorizationRequestTest {
             exception, "Invalid Request: transaction_data is not supported in the authorization request",
             expectedErrorCode = INVALID_TRANSACTION_DATA,
         )
+    }
+
+    @Test
+    fun `extractClientIdScheme should return pre-registered when client_id_scheme is explicitly set`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "mock-client", CLIENT_ID_SCHEME.value to PRE_REGISTERED.value)
+        assertEquals(PRE_REGISTERED.value, extractClientIdScheme(params))
+    }
+
+    @Test
+    fun `extractClientIdScheme should return did when client_id starts with did prefix`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "did:web:example.com:verifier")
+        assertEquals(ClientIdScheme.DID.value, extractClientIdScheme(params))
+    }
+
+    @Test
+    fun `extractClientIdScheme should return redirect_uri when client_id starts with redirect_uri prefix`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "redirect_uri:https://verifier.com/callback")
+        assertEquals(ClientIdScheme.REDIRECT_URI.value, extractClientIdScheme(params))
+    }
+
+    @Test
+    fun `extractClientIdScheme should return pre-registered when client_id has unrecognized prefix`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "https://verifier.com")
+        assertEquals(PRE_REGISTERED.value, extractClientIdScheme(params))
+    }
+
+    @Test
+    fun `extractClientIdScheme should return pre-registered when client_id has no colon`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "govt-verifier")
+        assertEquals(PRE_REGISTERED.value, extractClientIdScheme(params))
+    }
+
+    @Test
+    fun `extractClientIdScheme should return pre-registered for foo prefix`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "foo:bar")
+        assertEquals(PRE_REGISTERED.value, extractClientIdScheme(params))
+    }
+
+    @Test
+    fun `should treat client_id with URL colon as pre-registered and return full client_id`() {
+        val clientIdWithUrlColon = "https://verifier.com"
+        val trustedVerifiers = listOf(
+            Verifier(clientId = clientIdWithUrlColon, responseUris = listOf(responseUrl), allowUnsignedRequest = true)
+        )
+        val authorizationRequestParamsMap = requestParams + mapOf(CLIENT_ID.value to clientIdWithUrlColon)
+        val encodedAuthorizationRequest = createUrlEncodedData(authorizationRequestParamsMap, false, PRE_REGISTERED)
+
+        val actualValue = openID4VP.authenticateVerifier(encodedAuthorizationRequest, trustedVerifiers, shouldValidateClient)
+        assertEquals(clientIdWithUrlColon, actualValue.clientId)
+        assertEquals(responseUrl, actualValue.responseUri)
+    }
+
+    @Test
+    fun `should treat client_id without colon as pre-registered and return full client_id`() {
+        val plainClientId = "govt-verifier"
+        val trustedVerifiers = listOf(
+            Verifier(clientId = plainClientId, responseUris = listOf(responseUrl), allowUnsignedRequest = true)
+        )
+        val authorizationRequestParamsMap = requestParams + mapOf(CLIENT_ID.value to plainClientId)
+        val encodedAuthorizationRequest = createUrlEncodedData(authorizationRequestParamsMap, false, PRE_REGISTERED)
+
+        val actualValue = openID4VP.authenticateVerifier(encodedAuthorizationRequest, trustedVerifiers, shouldValidateClient)
+        assertEquals(plainClientId, actualValue.clientId)
+    }
+
+    @Test
+    fun `should throw InvalidVerifier when client_id with unrecognized prefix is not in trusted verifiers`() {
+        val authorizationRequestParamsMap = requestParams + mapOf(CLIENT_ID.value to "https://untrusted-verifier.com")
+        val encodedAuthorizationRequest = createUrlEncodedData(authorizationRequestParamsMap, false, PRE_REGISTERED)
+
+        val exception = assertFailsWith<OpenID4VPExceptions.InvalidVerifier> {
+            openID4VP.authenticateVerifier(encodedAuthorizationRequest, trustedVerifiers, shouldValidateClient)
+        }
+        assertOpenId4VPException(exception, "Verifier is not trusted by the wallet", expectedErrorCode = OpenID4VPErrorCodes.INVALID_CLIENT)
+    }
+
+    @Test
+    fun `should treat explicit pre-registered prefix in client_id and return full client_id`() {
+        val clientIdWithExplicitPrefix = "pre-registered:foo"
+        val trustedVerifiers = listOf(
+            Verifier(clientId = clientIdWithExplicitPrefix, responseUris = listOf(responseUrl), allowUnsignedRequest = true)
+        )
+        val authorizationRequestParamsMap = requestParams + mapOf(CLIENT_ID.value to clientIdWithExplicitPrefix)
+        val encodedAuthorizationRequest = createUrlEncodedData(authorizationRequestParamsMap, false, PRE_REGISTERED)
+
+        val actualValue = openID4VP.authenticateVerifier(encodedAuthorizationRequest, trustedVerifiers, shouldValidateClient)
+        assertEquals(clientIdWithExplicitPrefix, actualValue.clientId)
     }
 }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockkObject
 import io.mosip.openID4VP.OpenID4VP
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequestFieldConstants.*
 import io.mosip.openID4VP.authorizationRequest.authorizationRequestHandler.types.PreRegisteredSchemeAuthorizationRequestHandler
+import io.mosip.openID4VP.authorizationRequest.Verifier
 import io.mosip.openID4VP.common.OpenID4VPErrorCodes
 import io.mosip.openID4VP.common.OpenID4VPErrorCodes.INVALID_TRANSACTION_DATA
 import io.mosip.openID4VP.constants.ClientIdScheme
@@ -28,6 +29,7 @@ import io.mosip.openID4VP.testData.createUrlEncodedData
 import io.mosip.openID4VP.testData.presentationDefinitionString
 import io.mosip.openID4VP.testData.requestParams
 import io.mosip.openID4VP.testData.requestUrl
+import io.mosip.openID4VP.testData.responseUrl
 import io.mosip.openID4VP.testData.trustedVerifiers
 import io.mosip.openID4VP.testData.walletMetadata
 import io.mosip.openID4VP.testData.walletNonce
@@ -249,6 +251,45 @@ class AuthorizationRequestTest {
         val actualValue =
             openID4VP.authenticateVerifier(encodedAuthorizationRequest, trustedVerifiers,shouldValidateClient)
         assertTrue(actualValue is AuthorizationRequest)
+    }
+
+    @Test
+    fun `should treat client_id with unrecognized prefix as pre-registered client`() {
+        val clientIdWithUnknownPrefix = "foo:mock-client"
+        val trustedVerifiers = listOf(
+            Verifier(
+                clientId = clientIdWithUnknownPrefix,
+                responseUris = listOf(responseUrl),
+                allowUnsignedRequest = true
+            )
+        )
+
+        val authorizationRequestParamsMap = requestParams + mapOf(
+            CLIENT_ID.value to clientIdWithUnknownPrefix
+        )
+        val encodedAuthorizationRequest =
+            createUrlEncodedData(authorizationRequestParamsMap, false, PRE_REGISTERED)
+
+        val actualValue =
+            openID4VP.authenticateVerifier(encodedAuthorizationRequest, trustedVerifiers, shouldValidateClient)
+
+        assertEquals(clientIdWithUnknownPrefix, actualValue.clientId)
+        assertEquals(responseUrl, actualValue.responseUri)
+    }
+
+    @Test
+    fun `should validate trusted list for client_id with unrecognized prefix`() {
+        val authorizationRequestParamsMap = requestParams + mapOf(
+            CLIENT_ID.value to "foo:unknown-client"
+        )
+        val encodedAuthorizationRequest =
+            createUrlEncodedData(authorizationRequestParamsMap, false, PRE_REGISTERED)
+
+        val exception = assertFailsWith<OpenID4VPExceptions.InvalidVerifier> {
+            openID4VP.authenticateVerifier(encodedAuthorizationRequest, trustedVerifiers, shouldValidateClient)
+        }
+
+        assertEquals("Verifier is not trusted by the wallet", exception.message)
     }
 
     @Test

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestUtilsTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestUtilsTest.kt
@@ -1,0 +1,93 @@
+package io.mosip.openID4VP.authorizationRequest
+
+import io.mosip.openID4VP.authorizationRequest.AuthorizationRequestFieldConstants.CLIENT_ID
+import io.mosip.openID4VP.authorizationRequest.AuthorizationRequestFieldConstants.CLIENT_ID_SCHEME
+import io.mosip.openID4VP.constants.ClientIdScheme
+import io.mosip.openID4VP.constants.ClientIdScheme.PRE_REGISTERED
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AuthorizationRequestUtilsTest {
+
+    // --- extractClientIdScheme tests ---
+
+    @Test
+    fun `extractClientIdScheme should return pre-registered when client_id_scheme is explicitly set`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "mock-client", CLIENT_ID_SCHEME.value to PRE_REGISTERED.value)
+        assertEquals(PRE_REGISTERED.value, extractClientIdScheme(params))
+    }
+
+    @Test
+    fun `extractClientIdScheme should return did when client_id starts with did prefix`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "did:web:example.com:verifier")
+        assertEquals(ClientIdScheme.DID.value, extractClientIdScheme(params))
+    }
+
+    @Test
+    fun `extractClientIdScheme should return redirect_uri when client_id starts with redirect_uri prefix`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "redirect_uri:https://verifier.com/callback")
+        assertEquals(ClientIdScheme.REDIRECT_URI.value, extractClientIdScheme(params))
+    }
+
+    @Test
+    fun `extractClientIdScheme should return pre-registered when client_id has unrecognized prefix`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "https://verifier.com")
+        assertEquals(PRE_REGISTERED.value, extractClientIdScheme(params))
+    }
+
+    @Test
+    fun `extractClientIdScheme should return pre-registered when client_id has no colon`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "govt-verifier")
+        assertEquals(PRE_REGISTERED.value, extractClientIdScheme(params))
+    }
+
+    @Test
+    fun `extractClientIdScheme should return pre-registered for foo prefix`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "foo:bar")
+        assertEquals(PRE_REGISTERED.value, extractClientIdScheme(params))
+    }
+
+    // --- extractClientIdentifier tests ---
+
+    @Test
+    fun `extractClientIdentifier should return full client_id when client_id_scheme is explicitly present`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "mock-client", CLIENT_ID_SCHEME.value to PRE_REGISTERED.value)
+        assertEquals("mock-client", extractClientIdentifier(params))
+    }
+
+    @Test
+    fun `extractClientIdentifier should return full client_id for did scheme`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "did:web:example.com:verifier")
+        assertEquals("did:web:example.com:verifier", extractClientIdentifier(params))
+    }
+
+    @Test
+    fun `extractClientIdentifier should strip prefix for redirect_uri scheme`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "redirect_uri:https://verifier.com/callback")
+        assertEquals("https://verifier.com/callback", extractClientIdentifier(params))
+    }
+
+    @Test
+    fun `extractClientIdentifier should return full client_id for unrecognized prefix`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "https://verifier.com")
+        assertEquals("https://verifier.com", extractClientIdentifier(params))
+    }
+
+    @Test
+    fun `extractClientIdentifier should return full client_id when no colon present`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "govt-verifier")
+        assertEquals("govt-verifier", extractClientIdentifier(params))
+    }
+
+    @Test
+    fun `extractClientIdentifier should return full client_id for pre-registered prefix`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "pre-registered:foo")
+        assertEquals("pre-registered:foo", extractClientIdentifier(params))
+    }
+
+    @Test
+    fun `extractClientIdentifier should return full client_id for foo prefix`() {
+        val params = mapOf<String, Any>(CLIENT_ID.value to "foo:bar")
+        assertEquals("foo:bar", extractClientIdentifier(params))
+    }
+}


### PR DESCRIPTION
# Handle Unrecognized Client Identifier Prefix in OpenID4VP
- Treat unrecognized prefix client IDs as pre-registered clients
- Validate them against the trusted client list
- Perform verification similar to existing pre-registered client flows

## Github issue link
https://github.com/inji/inji-wallet/issues/2438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client_id parsing when no explicit scheme is provided: detects known prefixes, treats unknown prefixes as pre-registered, preserves DID and no-colon identifiers, and normalizes response URI handling to reject untrusted clients.

* **Tests**
  * Added comprehensive tests for recognized, unrecognized, colon-separated, URL-colon, no-colon, and DID client_id scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->