### PR TITLE
fix(authorization-request): URI validation, response_uri/redirect_uri and nonce handling

### DIFF
--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
@@ -149,6 +149,7 @@ class OpenID4VP @JvmOverloads constructor(
     }
 
     private fun safeSendError(exception: Exception) {
+        if (exception is OpenID4VPExceptions && !exception.notifyVerifier) return
         try {
             val verifierResponse = sendErrorInfoToVerifier(exception)
             (exception as? OpenID4VPExceptions)?.setVerifierResponse(verifierResponse)

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.kt
@@ -41,6 +41,8 @@ import io.mosip.openID4VP.constants.ClientIdPrefix
 import io.mosip.openID4VP.constants.ClientIdScheme
 import io.mosip.openID4VP.constants.ContentType
 import io.mosip.openID4VP.constants.HttpMethod
+import io.mosip.openID4VP.constants.ResponseMode.DIRECT_POST
+import io.mosip.openID4VP.constants.ResponseMode.DIRECT_POST_JWT
 import io.mosip.openID4VP.constants.SignatureAlgorithm
 import io.mosip.openID4VP.constants.RequestUriMethod
 import io.mosip.openID4VP.constants.SpecVersion
@@ -387,6 +389,15 @@ abstract class ClientIdPrefixBasedAuthorizationRequestHandler(
     fun setResponseUrl() {
         val responseMode = getStringValue(authorizationRequestParameters, RESPONSE_MODE.value)
             ?: throw OpenID4VPExceptions.MissingInput(listOf(RESPONSE_MODE.value), "", className)
+        // redirect_uri must not be present for direct_post / direct_post.jwt
+        if (responseMode == DIRECT_POST.value || responseMode == DIRECT_POST_JWT.value) {
+            if (authorizationRequestParameters.containsKey(REDIRECT_URI.value)) {
+                throw OpenID4VPExceptions.InvalidData(
+                    "${REDIRECT_URI.value} should not be present for given response_mode",
+                    className
+                )
+            }
+        }
         ResponseModeBasedHandlerFactory.get(responseMode)
             .setResponseUrl(authorizationRequestParameters, setResponseUri)
     }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.kt
@@ -412,8 +412,9 @@ abstract class ClientIdPrefixBasedAuthorizationRequestHandler(
         val responseType = getStringValue(authorizationRequestParameters, RESPONSE_TYPE.value)
         validate(RESPONSE_TYPE.value, responseType, className)
         validateResponseTypeSupported(responseType!!)
+        // missing nonce is not notified to the verifier
         val nonce = getStringValue(authorizationRequestParameters, NONCE.value)
-        validate(NONCE.value, nonce, className)
+        validate(NONCE.value, nonce, className, notifyVerifier = false)
         val state = getStringValue(authorizationRequestParameters, STATE.value)
         state?.let {
             validate(STATE.value, state, className)

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.kt
@@ -1,6 +1,5 @@
 package io.mosip.openID4VP.authorizationRequest.authorizationRequestHandler.types
 
-import io.mosip.openID4VP.authorizationRequest.AuthorizationRequestFieldConstants.REDIRECT_URI
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequestFieldConstants.RESPONSE_MODE
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequestFieldConstants.RESPONSE_URI
 import io.mosip.openID4VP.authorizationRequest.WalletConfig
@@ -66,11 +65,7 @@ class RedirectUriPrefixAuthorizationRequestHandler(
         throw OpenID4VPExceptions.MissingInput(listOf(RESPONSE_MODE.value), "", className)
          when (responseMode) {
             DIRECT_POST.value, DIRECT_POST_JWT.value -> {
-                validateUriCombinations(
-                    authorizationRequestParameters,
-                    RESPONSE_URI.value,
-                    REDIRECT_URI.value
-                )
+                validateResponseUriMatchesClientId(authorizationRequestParameters)
             }
              IAR_POST.value, IAR_POST_JWT.value -> {
                  logger.info("IAR_POST or IAR_POST_JWT response_mode is used")
@@ -79,21 +74,10 @@ class RedirectUriPrefixAuthorizationRequestHandler(
         }
     }
 
-    private fun validateUriCombinations(
-        authRequestParam: Map<String, Any>,
-        validAttribute: String,
-        inValidAttribute: String,
-    ) {
-        when {
-            authRequestParam.containsKey(inValidAttribute) -> {
-                throw OpenID4VPExceptions.InvalidData("$inValidAttribute should not be present for given response_mode", className)
-            }
-            else -> {
-                val data = getStringValue(authRequestParam, validAttribute)
-                validate(validAttribute, data, className)
-            }
-        }
-        if (authRequestParam[validAttribute] != extractClientIdPartOnly(authRequestParam))
-            throw OpenID4VPExceptions.InvalidData("$validAttribute should be equal to client_id for given client_id_prefix", className)
+    private fun validateResponseUriMatchesClientId(authRequestParam: Map<String, Any>) {
+        val responseUri = getStringValue(authRequestParam, RESPONSE_URI.value)
+        validate(RESPONSE_URI.value, responseUri, className)
+        if (authRequestParam[RESPONSE_URI.value] != extractClientIdPartOnly(authRequestParam))
+            throw OpenID4VPExceptions.InvalidData("${RESPONSE_URI.value} should be equal to client_id for given client_id_prefix", className)
     }
 }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
@@ -73,13 +73,14 @@ fun validate(
     key: String,
     value: String?,
     className: String,
-    fieldType: String = "String"
+    fieldType: String = "String",
+    notifyVerifier: Boolean = true
 ) {
     if (value == null || value == "null" || value.isEmpty()) {
         throw if (value == null) {
-            OpenID4VPExceptions.MissingInput(listOf(key), "", className)
+            OpenID4VPExceptions.MissingInput(listOf(key), "", className, notifyVerifier = notifyVerifier)
         } else {
-            OpenID4VPExceptions.InvalidInput(listOf(key), fieldType, className)
+            OpenID4VPExceptions.InvalidInput(listOf(key), fieldType, className, notifyVerifier = notifyVerifier)
         }
     }
 }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
@@ -27,11 +27,17 @@ import java.security.MessageDigest
 import java.security.SecureRandom
 import java.util.Base64
 
+// RFC 3986 (https://www.rfc-editor.org/rfc/rfc3986#section-3) https URI
 private const val URL_PATTERN =
-    "^https://(?:[\\w-]+\\.)+[\\w-]+(?::\\d+)?(?:/[\\w\\-.~!$&'()*+,;=:@%]+)*/?(?:\\?[^#\\s]*)?(?:#.*)?$"
+    "^https://(?:[\\w-]+\\.)+[\\w-]+(?::\\d+)?" +
+        "(?:/(?:[\\w\\-.~!$&'()*+,;=:@]|%[0-9A-Fa-f]{2})*)*" +
+        "(?:\\?(?:[\\w\\-.~!$&'()*+,;=:@/?]|%[0-9A-Fa-f]{2})*)?" +
+        "(?:#(?:[\\w\\-.~!$&'()*+,;=:@/?]|%[0-9A-Fa-f]{2})*)?$"
+
+private val URL_REGEX = Regex(URL_PATTERN)
 
 fun isValidUrl(url: String): Boolean {
-    return url.matches(URL_PATTERN.toRegex())
+    return URL_REGEX.matches(url)
 }
 
 fun convertJsonToMap(jsonString: String): MutableMap<String, Any> {

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/exceptions/openId4VPExceptions.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/exceptions/openId4VPExceptions.kt
@@ -15,6 +15,8 @@ sealed class OpenID4VPExceptions(
     val className: String,
     // holds the response received from the Verifier if the error is sent to the Verifier
     var verifierResponse: VerifierResponse? = null,
+    // whether this error should be dispatched to the Verifier; defaults to true
+    val notifyVerifier: Boolean = true,
     cause: Throwable? = null
 ) : Exception("$errorCode : $message", cause) {
 
@@ -107,7 +109,12 @@ sealed class OpenID4VPExceptions(
     )
 
 
-    class MissingInput(fieldPath: Any, message: String, className: String) :
+    class MissingInput(
+        fieldPath: Any,
+        message: String,
+        className: String,
+        notifyVerifier: Boolean = true
+    ) :
         OpenID4VPExceptions(
             INVALID_REQUEST,
             when {
@@ -117,10 +124,16 @@ sealed class OpenID4VPExceptions(
                     "Missing Input: ${fieldPath.joinToString("->")} param is required"
                 else -> message
             },
-            className
+            className,
+            notifyVerifier = notifyVerifier
         )
 
-    class InvalidInput(fieldPath: Any, fieldType: Any?, className: String) :
+    class InvalidInput(
+        fieldPath: Any,
+        fieldType: Any?,
+        className: String,
+        notifyVerifier: Boolean = true
+    ) :
         OpenID4VPExceptions(
             INVALID_REQUEST,
             "Invalid Input: ${
@@ -130,7 +143,8 @@ sealed class OpenID4VPExceptions(
                     else -> "${if (fieldPath is List<*> && fieldPath.isNotEmpty()) fieldPath.joinToString("->") else fieldPath} value cannot be empty or null"
                 }
             }",
-            className
+            className,
+            notifyVerifier = notifyVerifier
         )
 
 

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/OpenID4VPErrorDispatchTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/OpenID4VPErrorDispatchTest.kt
@@ -67,6 +67,30 @@ class OpenID4VPErrorDispatchTest {
     }
 
     @Test
+    fun `authenticateVerifier does not notify verifier when nonce is missing`() {
+        val instance = OpenID4VP("test")
+        setField(instance, "responseUri", "https://mock-verifier.com/response-uri")
+
+        every {
+            NetworkManagerClient.sendHTTPRequest(any(), any(), any(), any())
+        } returns NetworkResponse(200, "{}", mapOf())
+
+        every {
+            AuthorizationRequest.validateAndCreateAuthorizationRequest(
+                any<String>(), any(), any(), any()
+            )
+        } throws OpenID4VPExceptions.MissingInput(listOf("nonce"), "", "test", notifyVerifier = false)
+
+        val thrown = assertFailsWith<OpenID4VPExceptions.MissingInput> {
+            instance.authenticateVerifier("bad")
+        }
+
+        // Verifier must NOT be notified for a missing nonce
+        assertNull(thrown.verifierResponse)
+        verify(exactly = 0) { NetworkManagerClient.sendHTTPRequest(any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `authenticateVerifier does not crash if error dispatch itself fails`() {
         val instance = OpenID4VP("test")
 

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandlerTest.kt
@@ -187,6 +187,43 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
     }
 
     @Test
+    fun `setResponseUrl should reject both response_uri and redirect_uri for direct_post`() {
+        authorizationRequestParameters[REDIRECT_URI.value] = "https://example.com/redirect"
+        val handler = PreRegisteredSchemeAuthorizationRequestHandler(
+            validClientId,
+            SpecVersion.DRAFT_23,
+            authorizationRequestParameters,
+            walletConfig,
+            setResponseUri,
+            walletNonce
+        )
+
+        val exception = assertFailsWith<OpenID4VPExceptions.InvalidData> {
+            handler.setResponseUrl()
+        }
+        assertTrue(exception.message?.contains("redirect_uri should not be present") == true)
+    }
+
+    @Test
+    fun `setResponseUrl should reject both response_uri and redirect_uri for direct_post_jwt`() {
+        authorizationRequestParameters[RESPONSE_MODE.value] = "direct_post.jwt"
+        authorizationRequestParameters[REDIRECT_URI.value] = "https://example.com/redirect"
+        val handler = PreRegisteredSchemeAuthorizationRequestHandler(
+            validClientId,
+            SpecVersion.DRAFT_23,
+            authorizationRequestParameters,
+            walletConfig,
+            setResponseUri,
+            walletNonce
+        )
+
+        val exception = assertFailsWith<OpenID4VPExceptions.InvalidData> {
+            handler.setResponseUrl()
+        }
+        assertTrue(exception.message?.contains("redirect_uri should not be present") == true)
+    }
+
+    @Test
     fun `validateAndParseRequestFields should throw exception when response URI is not trusted`() {
         authorizationRequestParameters[RESPONSE_URI.value] =
             "https://untrusted.verifier.com/response"

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriSchemeAuthorizationRequestHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriSchemeAuthorizationRequestHandlerTest.kt
@@ -198,11 +198,22 @@ class RedirectUriSchemeAuthorizationRequestHandlerTest {
     }
 
     @Test
-    fun `validateAndParseRequestFields should throw exception when REDIRECT_URI is present`() {
+    fun `setResponseUrl should throw exception when REDIRECT_URI is present for direct_post`() {
         val modifiedParams = authorizationRequestParameters.toMutableMap()
         modifiedParams[REDIRECT_URI.value] = "https://example.com/redirect"
         val exception = assertFailsWith<OpenID4VPExceptions.InvalidData> {
-            createHandler(modifiedParams).validateAndParseRequestFields()
+            createHandler(modifiedParams).setResponseUrl()
+        }
+        assertTrue(exception.message?.contains("redirect_uri should not be present") == true)
+    }
+
+    @Test
+    fun `setResponseUrl should throw exception when REDIRECT_URI is present for direct_post_jwt`() {
+        val modifiedParams = authorizationRequestParameters.toMutableMap()
+        modifiedParams[RESPONSE_MODE.value] = "direct_post.jwt"
+        modifiedParams[REDIRECT_URI.value] = "https://example.com/redirect"
+        val exception = assertFailsWith<OpenID4VPExceptions.InvalidData> {
+            createHandler(modifiedParams).setResponseUrl()
         }
         assertTrue(exception.message?.contains("redirect_uri should not be present") == true)
     }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/common/UtilsTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/common/UtilsTest.kt
@@ -11,9 +11,20 @@ import kotlin.test.*
 class UtilsTest {
 
     @Test
-    fun `isValidUrl should return true for valid URL`() {
-        val url = "https://example.com/path?query=value#fragment"
-        assertTrue(isValidUrl(url))
+    fun `isValidUrl should return true for valid URLs per RFC 3986`() {
+        val validUrls = listOf(
+            "https://example.com/path?query=value#fragment",
+            // RFC 3986 structure: port + multi-segment path + query + fragment
+            "https://example.com:8042/over/there?name=ferret#nose",
+            // percent-encoded octets in path and query
+            "https://example.com/a%20b?q=hello%20world",
+            // empty path segment
+            "https://example.com//empty/seg",
+            // '/', '?' and '@' allowed within query and fragment
+            "https://example.com/p?a=1/2&b=x?y#f/g?h"
+        )
+
+        validUrls.forEach { url -> assertTrue(isValidUrl(url), "expected valid: $url") }
     }
 
     @Test
@@ -31,10 +42,18 @@ class UtilsTest {
             "http://example.com/search?q=hello%20world#@fragment",
             "http://:8080",
             "",
-            "https://example.com/invalid|character"
+            "https://example.com/invalid|character",
+            // non-https scheme is rejected even with valid RFC 3986 structure
+            "foo://example.com:8042/over/there?name=ferret#nose",
+            // malformed percent-encoding (not followed by two hex digits)
+            "https://example.com/file%/name",
+            // whitespace is not allowed
+            "https://example.com/space here",
+            // trailing newline must not be accepted
+            "https://example.com/path\n"
         )
 
-        testUrls.forEach { url -> assertFalse(isValidUrl(url)) }
+        testUrls.forEach { url -> assertFalse(isValidUrl(url), "expected invalid: $url") }
     }
 
 


### PR DESCRIPTION
Validates request/response/presentation-definition URIs against an RFC 3986 https pattern, rejects requests carrying both response_uri and redirect_uri for direct_post / direct_post.jwt across all client_id_prefixes, and skips notifying the Verifier when nonce is missing.
