### PR TITLE
add: ECDH_ES encryption support with EC Keys | fix: direct_post.jwt response mode VP token encoding

### DIFF
--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponse.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponse.kt
@@ -48,7 +48,7 @@ fun AuthorizationResponse.toJsonEncodedMap(): Map<String, String> {
 }
 
 fun AuthorizationResponse.toMap(): Map<String, Any> {
-    val objectMapper = getObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
+    val objectMapper = getObjectMapper().copy().setSerializationInclusion(JsonInclude.Include.NON_NULL)
     return when (this) {
         is AuthorizationResponse.PresentationExchange -> buildMap {
             put("vp_token", objectMapper.convertValue(vpToken, object : TypeReference<Any>() {}))

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponse.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponse.kt
@@ -1,11 +1,13 @@
 package io.mosip.openID4VP.authorizationResponse
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.core.type.TypeReference
 import com.google.gson.annotations.SerializedName
 import io.mosip.openID4VP.authorizationResponse.presentationSubmission.PresentationSubmission
-import io.mosip.openID4VP.authorizationResponse.vpToken.VPTokenType
 import io.mosip.openID4VP.authorizationResponse.vpToken.VPToken
+import io.mosip.openID4VP.authorizationResponse.vpToken.VPTokenType
 import io.mosip.openID4VP.common.encodeToJsonString
-import io.mosip.openID4VP.common.encodeToJsonString
+import io.mosip.openID4VP.common.getObjectMapper
 
 private val className: String = AuthorizationResponse::class.simpleName!!
 
@@ -36,11 +38,29 @@ fun AuthorizationResponse.toJsonEncodedMap(): Map<String, String> {
                     className
                 )
             )
-            state?.let<String, Unit> { put("state", it) }
+            state?.let { put("state", it) }
         }
         is AuthorizationResponse.Dcql -> buildMap {
             put("vp_token", encodeToJsonString(vpToken, "vp_token", className))
-            state?.let<String, Unit> { put("state", it) }
+            state?.let { put("state", it) }
+        }
+    }
+}
+
+fun AuthorizationResponse.toMap(): Map<String, Any> {
+    val objectMapper = getObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
+    return when (this) {
+        is AuthorizationResponse.PresentationExchange -> buildMap {
+            put("vp_token", objectMapper.convertValue(vpToken, object : TypeReference<Any>() {}))
+            put(
+                "presentation_submission",
+                objectMapper.convertValue(presentationSubmission, object : TypeReference<Map<String, Any>>() {})
+            )
+            state?.let { put("state", it) }
+        }
+        is AuthorizationResponse.Dcql -> buildMap {
+            put("vp_token", objectMapper.convertValue(vpToken, object : TypeReference<Any>() {}))
+            state?.let { put("state", it) }
         }
     }
 }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/exceptions/openId4VPExceptions.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/exceptions/openId4VPExceptions.kt
@@ -181,6 +181,13 @@ sealed class OpenID4VPExceptions(
             className
         )
 
+    class UnsupportedOperationException(message: String, className: String) :
+        OpenID4VPExceptions(
+            INVALID_REQUEST,
+            message,
+            className
+        )
+
     class JweEncryptionFailure(message: String, className: String, cause: Throwable? = null) :
         OpenID4VPExceptions(
             INVALID_REQUEST,

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/exceptions/openId4VPExceptions.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/exceptions/openId4VPExceptions.kt
@@ -181,10 +181,10 @@ sealed class OpenID4VPExceptions(
             className
         )
 
-    class JweEncryptionFailure(className: String, cause: Throwable? = null) :
+    class JweEncryptionFailure(message: String, className: String, cause: Throwable? = null) :
         OpenID4VPExceptions(
             INVALID_REQUEST,
-            "JWE Encryption failed",
+            message,
             className,
             cause = cause
         )

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/jwt/jwe/JWEHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/jwt/jwe/JWEHandler.kt
@@ -23,8 +23,6 @@ class JWEHandler(
 
     fun generateEncryptedResponse(payload: Map<String, Any>): String {
         try {
-            val payloadString = getObjectMapper().writeValueAsString(payload)
-
             val header = JWEHeader.Builder(
                 JWEAlgorithm.parse(keyEncryptionAlg),
                 EncryptionMethod.parse(contentEncryptionAlg)
@@ -35,7 +33,7 @@ class JWEHandler(
                 .build()
 
             val encrypter = EncryptionProvider.getEncrypter(publicKey)
-            val jweObject = JWEObject(header, Payload(payloadString))
+            val jweObject = JWEObject(header, Payload(payload))
             jweObject.encrypt(encrypter)
 
             return jweObject.serialize()

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/jwt/jwe/JWEHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/jwt/jwe/JWEHandler.kt
@@ -7,6 +7,7 @@ import com.nimbusds.jose.JWEObject
 import com.nimbusds.jose.Payload
 import com.nimbusds.jose.util.Base64URL
 import io.mosip.openID4VP.authorizationRequest.clientMetadata.Jwk
+import io.mosip.openID4VP.common.getObjectMapper
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.jwt.jwe.encryption.EncryptionProvider
 
@@ -22,7 +23,7 @@ class JWEHandler(
 
     fun generateEncryptedResponse(payload: Map<String, Any>): String {
         try {
-            val payloadString = io.mosip.openID4VP.common.getObjectMapper().writeValueAsString(payload)
+            val payloadString = getObjectMapper().writeValueAsString(payload)
 
             val header = JWEHeader.Builder(
                 JWEAlgorithm.parse(keyEncryptionAlg),
@@ -39,7 +40,11 @@ class JWEHandler(
 
             return jweObject.serialize()
         } catch (exception: Exception) {
-            throw OpenID4VPExceptions.JweEncryptionFailure(className, exception)
+            throw OpenID4VPExceptions.JweEncryptionFailure(
+                "JWE Encryption failed : " + (exception.message ?: "Unknown error"),
+                className,
+                exception
+            )
         }
     }
 }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/jwt/jwe/JWEHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/jwt/jwe/JWEHandler.kt
@@ -22,6 +22,12 @@ class JWEHandler(
 ) {
 
     fun generateEncryptedResponse(payload: Map<String, Any>): String {
+        if (keyEncryptionAlg != "ECDH-ES" || contentEncryptionAlg != "A256GCM") {
+            throw OpenID4VPExceptions.UnsupportedOperationException(
+                "Unsupported encryption configuration: keyEncryptionAlgorithm=$keyEncryptionAlg, contentEncryptionAlgorithm=$contentEncryptionAlg. Supported configuration: keyEncryptionAlgorithm=ECDH-ES, contentEncryptionAlgorithm=A256GCM",
+                className
+            )
+        }
         try {
             val header = JWEHeader.Builder(
                 JWEAlgorithm.parse(keyEncryptionAlg),

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/jwt/jwe/encryption/EncryptionProvider.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/jwt/jwe/encryption/EncryptionProvider.kt
@@ -1,25 +1,66 @@
 package io.mosip.openID4VP.jwt.jwe.encryption
 
 import com.nimbusds.jose.Algorithm
-import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.JWEEncrypter
+import com.nimbusds.jose.crypto.ECDHEncrypter
 import com.nimbusds.jose.crypto.X25519Encrypter
 import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.KeyType
 import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.OctetKeyPair
 import com.nimbusds.jose.util.Base64URL
 import io.mosip.openID4VP.authorizationRequest.clientMetadata.Jwk
+import io.mosip.openID4VP.constants.EncryptionAlgorithm
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 
 private val className = EncryptionProvider::class.simpleName!!
 object EncryptionProvider {
 
-    fun getEncrypter(jwk: Jwk): JWEEncrypter =
-        when (jwk.kty) {
-            KeyType.OKP.value -> X25519Encrypter(getPublicOctetKey(jwk))
+    private val supportedEncryptionAlgs = setOf(
+        EncryptionAlgorithm.ECDH_ES.value
+    )
+
+    fun getEncrypter(jwk: Jwk): JWEEncrypter {
+        if (jwk.alg !in supportedEncryptionAlgs) {
+            throw OpenID4VPExceptions.JweEncryptionFailure(
+                "Unsupported JWE algorithm: ${jwk.alg}",
+                className
+            )
+        }
+
+        return when (jwk.kty) {
+            KeyType.OKP.value -> {
+                if (jwk.crv != Curve.X25519.name) {
+                    throw OpenID4VPExceptions.JweEncryptionFailure(
+                        "Unsupported OKP curve for ECDH-ES: ${jwk.crv}. Only X25519 is supported.",
+                        className
+                    )
+                }
+
+                X25519Encrypter(getPublicOctetKey(jwk))
+            }
+
+            KeyType.EC.value -> {
+                if (
+                    jwk.crv !in setOf(
+                        Curve.P_256.name,
+                        Curve.P_384.name,
+                        Curve.P_521.name
+                    )
+                ) {
+                    throw OpenID4VPExceptions.JweEncryptionFailure(
+                        className,
+                        "Unsupported recipient key type: ${jwk.kty}"
+                    )
+                }
+
+                ECDHEncrypter(getPublicEcKey(jwk))
+            }
+
             else -> throw OpenID4VPExceptions.UnsupportedKeyExchangeAlgorithm(className)
         }
+    }
 
     private fun getPublicOctetKey(jwk: Jwk): OctetKeyPair {
         val builder = OctetKeyPair.Builder(Curve(jwk.crv), Base64URL.from(jwk.x))
@@ -31,5 +72,20 @@ object EncryptionProvider {
         return builder
             .build()
             .toPublicJWK()
+    }
+
+    private fun getPublicEcKey(jwk: Jwk): ECKey {
+        val y = jwk.y ?: throw OpenID4VPExceptions.UnsupportedKeyExchangeAlgorithm(className)
+        val builder = ECKey.Builder(
+            Curve(jwk.crv),
+            Base64URL.from(jwk.x),
+            Base64URL.from(y)
+        )
+            .keyID(jwk.kid)
+            .algorithm(Algorithm.parse(jwk.alg))
+
+        jwk.use?.let { builder.keyUse(KeyUse(it)) }
+
+        return builder.build().toPublicJWK()
     }
 }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/jwt/jwe/encryption/EncryptionProvider.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/jwt/jwe/encryption/EncryptionProvider.kt
@@ -50,8 +50,8 @@ object EncryptionProvider {
                     )
                 ) {
                     throw OpenID4VPExceptions.JweEncryptionFailure(
-                        className,
-                        "Unsupported recipient key type: ${jwk.kty}"
+                        "Unsupported EC curve for ECDH-ES: ${jwk.crv}. Only P-256, P-384, P-521 are supported.",
+                        className
                     )
                 }
 

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostJwtResponseModeHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostJwtResponseModeHandler.kt
@@ -10,6 +10,7 @@ import io.mosip.openID4VP.authorizationRequest.clientMetadata.Jwk
 import io.mosip.openID4VP.authorizationResponse.AuthorizationErrorResponse
 import io.mosip.openID4VP.authorizationResponse.AuthorizationResponse
 import io.mosip.openID4VP.authorizationResponse.toJsonEncodedMap
+import io.mosip.openID4VP.authorizationResponse.toMap
 import io.mosip.openID4VP.constants.EncryptionMethod
 import io.mosip.openID4VP.jwt.jwe.JWEHandler
 import io.mosip.openID4VP.constants.ContentType
@@ -149,7 +150,7 @@ class DirectPostJwtResponseModeHandler : ResponseModeBasedHandler() {
     ): Map<String, String> {
         return encryptResponse(
             authorizationRequest, walletNonce,
-            authorizationResponse.toJsonEncodedMap(),
+            authorizationResponse.toMap(),
             walletConfig
         )
     }
@@ -173,7 +174,7 @@ class DirectPostJwtResponseModeHandler : ResponseModeBasedHandler() {
     private fun encryptResponse(
         authorizationRequest: AuthorizationRequest,
         walletNonce: String,
-        responseParams: Map<String, String>,
+        responseParams: Map<String, Any>,
         walletConfig: WalletConfig
     ): Map<String, String> {
         val specVersionHandler = SpecVersionHandler.from(authorizationRequest)

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseTest.kt
@@ -61,4 +61,96 @@ class AuthorizationResponseTest {
         assertTrue(map.containsKey("presentation_submission"))
         assertFalse(map.containsKey("state"))
     }
+
+    @Test
+    fun `toMap should filter out null values`() {
+        val responseWithNullState = AuthorizationResponse.PresentationExchange(
+            presentationSubmission = presentationSubmission,
+            vpToken = vpToken,
+            state = null
+        )
+        val map = responseWithNullState.toMap()
+        assertEquals(2, map.size)
+        assertTrue(map.containsKey("vp_token"))
+        assertTrue(map.containsKey("presentation_submission"))
+        assertFalse(map.containsKey("state"))
+    }
+
+    @Test
+    fun `toMap should return exact expected map`() {
+        val expectedVpTokenMap = mapOf(
+            "@context" to listOf("context"),
+            "type" to listOf("type"),
+            "verifiableCredential" to listOf("VC1"),
+            "id" to "id",
+            "holder" to "holder",
+            "proof" to mapOf(
+                "type" to "type",
+                "created" to "time",
+                "challenge" to "challenge",
+                "domain" to "domain",
+                "proofValue" to "eryy....ewr",
+                "proofPurpose" to "authentication",
+                "verificationMethod" to "did:example:holder#key-1"
+            )
+        )
+
+        val expectedPresentationSubmissionMap = mapOf(
+            "id" to "ps_id",
+            "definition_id" to "client_id",
+            "descriptor_map" to listOf(
+                mapOf(
+                    "id" to "input_descriptor_1",
+                    "format" to "ldp_vp",
+                    "path" to "$",
+                    "path_nested" to mapOf(
+                        "id" to "input_descriptor_1",
+                        "format" to "ldp_vp",
+                        "path" to "$.verifiableCredential[0]"
+                    )
+                )
+            )
+        )
+
+        val expectedMap = mapOf(
+            "vp_token" to expectedVpTokenMap,
+            "presentation_submission" to expectedPresentationSubmissionMap,
+            "state" to "state"
+        )
+
+        val actualMap = authorizationResponse.toMap()
+        assertEquals(expectedMap, actualMap)
+    }
+
+    @Test
+    fun `toMap should return objects for Dcql response`() {
+        val dcqlResponse = AuthorizationResponse.Dcql(
+            vpToken = mapOf("credential1" to listOf(ldpVPToken)),
+            state = "state_123"
+        )
+        val expectedVpTokenMap = mapOf(
+            "@context" to listOf("context"),
+            "type" to listOf("type"),
+            "verifiableCredential" to listOf("VC1"),
+            "id" to "id",
+            "holder" to "holder",
+            "proof" to mapOf(
+                "type" to "type",
+                "created" to "time",
+                "challenge" to "challenge",
+                "domain" to "domain",
+                "proofValue" to "eryy....ewr",
+                "proofPurpose" to "authentication",
+                "verificationMethod" to "did:example:holder#key-1"
+            )
+        )
+        
+        val expectedMap = mapOf(
+            "vp_token" to mapOf("credential1" to listOf(expectedVpTokenMap)),
+            "state" to "state_123"
+        )
+
+        val actualMap = dcqlResponse.toMap()
+        assertEquals(expectedMap, actualMap)
+    }
 }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/jwt/jwe/JWEHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/jwt/jwe/JWEHandlerTest.kt
@@ -21,7 +21,7 @@ class JWEHandlerTest {
     @BeforeTest
     fun setUp() {
         clientMetadata = deserializeAndValidate(clientMetadataString, ClientMetadataDraft23Serializer)
-        publicKey = clientMetadata.jwks!!.keys[0]
+        publicKey = clientMetadata.jwks!!.keys[1]
         jweHandler = JWEHandler(
             "ECDH-ES",
             "A256GCM",

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/jwt/jwe/JWEHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/jwt/jwe/JWEHandlerTest.kt
@@ -74,6 +74,32 @@ class JWEHandlerTest {
         val exception = assertFailsWith<OpenID4VPExceptions.JweEncryptionFailure> {
             handler.generateEncryptedResponse(payload)
         }
-        assertEquals(true, exception.message?.startsWith("JWE Encryption failed"))
+        assertTrue(exception.message!!.contains("JWE Encryption failed"))
+    }
+
+    @Test
+    fun `should throw UnsupportedOperationException when keyEncryptionAlg is unsupported`() {
+        val payload = mapOf("key1" to "value1")
+        val handler = JWEHandler("RSA-OAEP", "A256GCM", publicKey, walletNonce, verifierNonce)
+        
+        val exception = assertFailsWith<OpenID4VPExceptions.UnsupportedOperationException> {
+            handler.generateEncryptedResponse(payload)
+        }
+        
+        val expectedMessage = "Unsupported encryption configuration: keyEncryptionAlgorithm=RSA-OAEP, contentEncryptionAlgorithm=A256GCM. Supported configuration: keyEncryptionAlgorithm=ECDH-ES, contentEncryptionAlgorithm=A256GCM"
+        assertTrue(exception.message.contains(expectedMessage))
+    }
+
+    @Test
+    fun `should throw UnsupportedOperationException when contentEncryptionAlg is unsupported`() {
+        val payload = mapOf("key1" to "value1")
+        val handler = JWEHandler("ECDH-ES", "A128GCM", publicKey, walletNonce, verifierNonce)
+        
+        val exception = assertFailsWith<OpenID4VPExceptions.UnsupportedOperationException> {
+            handler.generateEncryptedResponse(payload)
+        }
+        
+        val expectedMessage = "Unsupported encryption configuration: keyEncryptionAlgorithm=ECDH-ES, contentEncryptionAlgorithm=A128GCM. Supported configuration: keyEncryptionAlgorithm=ECDH-ES, contentEncryptionAlgorithm=A256GCM"
+        assertTrue(exception.message.contains(expectedMessage))
     }
 }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/jwt/jwe/encryption/EncryptionProviderTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/jwt/jwe/encryption/EncryptionProviderTest.kt
@@ -63,7 +63,7 @@ class EncryptionProviderTest {
         // Current implementation populates class name as the exception message in this branch.
         assertOpenId4VPException(
             exception,
-            expectedMessage = "EncryptionProvider",
+            expectedMessage = "Unsupported EC curve for ECDH-ES: secp256k1. Only P-256, P-384, P-521 are supported.",
             expectedErrorCode = OpenID4VPErrorCodes.INVALID_REQUEST
         )
     }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/jwt/jwe/encryption/EncryptionProviderTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/jwt/jwe/encryption/EncryptionProviderTest.kt
@@ -1,51 +1,124 @@
 package io.mosip.openID4VP.jwt.jwe.encryption
 
+import com.nimbusds.jose.crypto.ECDHEncrypter
 import com.nimbusds.jose.crypto.X25519Encrypter
-import io.mockk.clearAllMocks
 import io.mosip.openID4VP.authorizationRequest.clientMetadata.Jwk
 import io.mosip.openID4VP.common.OpenID4VPErrorCodes
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
-import kotlin.test.*
-
+import io.mosip.openID4VP.testData.assertOpenId4VPException
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
 
 class EncryptionProviderTest {
 
-
-    @AfterTest
-    fun tearDown() {
-        clearAllMocks()
-    }
-
     @Test
-    fun `getEncrypter should create X25519Encrypter for OKP key type`() {
-        val jwk = Jwk(
-            alg = "ECDH-ES",
-            kty = "OKP",
-            use = "enc",
-            crv = "X25519",
-            x = "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
-            kid = "ed-key1"
-        )
-        val encrypter = EncryptionProvider.getEncrypter(jwk)
+    fun `getEncrypter should create X25519Encrypter for OKP with X25519`() {
+        val encrypter = EncryptionProvider.getEncrypter(baseOkpJwk())
 
         assertTrue(encrypter is X25519Encrypter)
     }
 
     @Test
-    fun `getEncrypter should throw UnsupportedKeyExchangeAlgorithm for non-OKP key type`() {
-        val jwk = Jwk(
-            alg = "ECDH-ES",
-            kty = "UNSUPPORTED",
-            use = "enc",
-            crv = "X25519",
-            x = "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
-            kid = "ed-key1"
-        )
+    fun `getEncrypter should create ECDHEncrypter for supported EC curve`() {
+        val encrypter = EncryptionProvider.getEncrypter(baseEcJwk())
 
-        val exception = assertFailsWith<OpenID4VPExceptions.UnsupportedKeyExchangeAlgorithm> {
-            EncryptionProvider.getEncrypter(jwk)
-        }
-        assertEquals(OpenID4VPErrorCodes.INVALID_REQUEST, exception.errorCode)
-        assertEquals("Required Key exchange algorithm is not supported", exception.message)
+        assertTrue(encrypter is ECDHEncrypter)
     }
+
+    @Test
+    fun `getEncrypter should throw JweEncryptionFailure for unsupported or missing algorithm`() {
+        listOf("RSA-OAEP", null).forEach { alg ->
+            val exception = assertFailsWith<OpenID4VPExceptions.JweEncryptionFailure> {
+                EncryptionProvider.getEncrypter(baseOkpJwk(alg = alg))
+            }
+
+            assertOpenId4VPException(
+                exception,
+                expectedMessage = "Unsupported JWE algorithm: $alg",
+                expectedErrorCode = OpenID4VPErrorCodes.INVALID_REQUEST
+            )
+        }
+    }
+
+    @Test
+    fun `getEncrypter should throw JweEncryptionFailure for OKP with non-X25519 curve`() {
+        val exception = assertFailsWith<OpenID4VPExceptions.JweEncryptionFailure> {
+            EncryptionProvider.getEncrypter(baseOkpJwk(crv = "Ed25519"))
+        }
+
+        assertOpenId4VPException(
+            exception,
+            expectedMessage = "Unsupported OKP curve for ECDH-ES: Ed25519. Only X25519 is supported.",
+            expectedErrorCode = OpenID4VPErrorCodes.INVALID_REQUEST
+        )
+    }
+
+    @Test
+    fun `getEncrypter should throw JweEncryptionFailure for EC with unsupported curve`() {
+        val exception = assertFailsWith<OpenID4VPExceptions.JweEncryptionFailure> {
+            EncryptionProvider.getEncrypter(baseEcJwk(crv = "secp256k1"))
+        }
+
+        // Current implementation populates class name as the exception message in this branch.
+        assertOpenId4VPException(
+            exception,
+            expectedMessage = "EncryptionProvider",
+            expectedErrorCode = OpenID4VPErrorCodes.INVALID_REQUEST
+        )
+    }
+
+    @Test
+    fun `getEncrypter should throw UnsupportedKeyExchangeAlgorithm for unsupported key type`() {
+        val exception = assertFailsWith<OpenID4VPExceptions.UnsupportedKeyExchangeAlgorithm> {
+            EncryptionProvider.getEncrypter(baseOkpJwk(kty = "RSA"))
+        }
+
+        assertOpenId4VPException(
+            exception,
+            expectedMessage = "Required Key exchange algorithm is not supported",
+            expectedErrorCode = OpenID4VPErrorCodes.INVALID_REQUEST
+        )
+    }
+
+    @Test
+    fun `getEncrypter should throw UnsupportedKeyExchangeAlgorithm for EC key without y coordinate`() {
+        val exception = assertFailsWith<OpenID4VPExceptions.UnsupportedKeyExchangeAlgorithm> {
+            EncryptionProvider.getEncrypter(baseEcJwk(y = null))
+        }
+
+        assertOpenId4VPException(
+            exception,
+            expectedMessage = "Required Key exchange algorithm is not supported",
+            expectedErrorCode = OpenID4VPErrorCodes.INVALID_REQUEST
+        )
+    }
+
+    private fun baseOkpJwk(
+        alg: String? = "ECDH-ES",
+        kty: String = "OKP",
+        crv: String? = "X25519"
+    ): Jwk = Jwk(
+        alg = alg,
+        kty = kty,
+        use = "enc",
+        crv = crv,
+        x = "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
+        kid = "okp-key-1"
+    )
+
+    private fun baseEcJwk(
+        alg: String? = "ECDH-ES",
+        kty: String = "EC",
+        crv: String? = "P-256",
+        y: String? = "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
+    ): Jwk = Jwk(
+        alg = alg,
+        kty = kty,
+        use = "enc",
+        crv = crv,
+        x = "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+        y = y,
+        kid = "ec-key-1"
+    )
 }

--- a/kotlin/openID4VP/src/jvmTest/kotlin/io/mosip/openID4VP/jwt/JWEHandlerJvmTest.kt
+++ b/kotlin/openID4VP/src/jvmTest/kotlin/io/mosip/openID4VP/jwt/JWEHandlerJvmTest.kt
@@ -23,7 +23,7 @@ class JWEHandlerJvmTest {
     @BeforeTest
     fun setUp() {
         clientMetadata = deserializeAndValidate(clientMetadataString, ClientMetadataDraft23Serializer)
-        publicKey = clientMetadata.jwks!!.keys[0]
+        publicKey = clientMetadata.jwks!!.keys[1]
         jweHandler = JWEHandler(
             clientMetadata.authorizationEncryptedResponseAlg!!,
             clientMetadata.authorizationEncryptedResponseEnc!!,


### PR DESCRIPTION
Fixes: https://github.com/inji/inji-wallet/issues/2482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting authorization responses into structured map data for downstream processing.
  * Expanded encryption support to handle additional key types and curves.

* **Bug Fixes**
  * Improved encrypted response generation for more reliable payload handling.
  * Enhanced error reporting for encryption failures with clearer messages.
  * Tightened validation to reject unsupported or incomplete keys earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->