### PR TITLE
fix: avoid notifying verifier when redirect_uri client ID and response_uri validation fails

### DIFF
--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.kt
@@ -78,7 +78,8 @@ abstract class ClientIdPrefixBasedAuthorizationRequestHandler(
 
     open fun confirmSpecVersionIdentifiedFromRequest(): Boolean = true
 
-    // Validate if the Client is Valid or Some issues occur. This focuses on checking if a Client Posing as Say Pre-registered is actually pre-registered
+    /// Validates the authenticity of the client identifier.
+    /// For example, ensures that a client claiming to use a specific prefix is actually authorized or trusted.
     open fun validateClientAuthenticity() {}
 
     fun handle(): AuthorizationRequest {

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.kt
@@ -78,9 +78,13 @@ abstract class ClientIdPrefixBasedAuthorizationRequestHandler(
 
     open fun confirmSpecVersionIdentifiedFromRequest(): Boolean = true
 
+    // Validate if the Client is Valid or Some issues occur. This focuses on checking if a Client Posing as Say Pre-registered is actually pre-registered
+    open fun validateClientAuthenticity() {}
+
     fun handle(): AuthorizationRequest {
         validateClientId()
         fetchAuthorizationRequest()
+        validateClientAuthenticity()
         setResponseUrl()
         validateAndParseRequestFields()
         return createAuthorizationRequest()
@@ -361,16 +365,13 @@ abstract class ClientIdPrefixBasedAuthorizationRequestHandler(
     }
 
     private fun validateAuthorizationSignatureAlgorithm(algorithm: String) {
-        if (shouldValidateWithWalletMetadata) {
-            if (!walletConfig.requestObjectSigningAlgValuesSupported!!.contains(
-                    SignatureAlgorithm.fromValue(algorithm)
-                )
+        if (shouldValidateWithWalletMetadata && !walletConfig.requestObjectSigningAlgValuesSupported!!.contains(
+                SignatureAlgorithm.fromValue(algorithm)
             )
-                throw OpenID4VPExceptions.InvalidData(
-                    "request_object_signing_alg is not supported by wallet",
-                    className
-                )
-        }
+        ) throw OpenID4VPExceptions.InvalidData(
+            "request_object_signing_alg is not supported by wallet",
+            className
+        )
     }
 
     abstract fun getWalletMetadata(walletConfig: WalletConfig): Map<String, Any>

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.kt
@@ -144,7 +144,7 @@ abstract class ClientIdPrefixBasedAuthorizationRequestHandler(
         val requestUriMethod =
             getStringValue(authorizationRequestParameters, REQUEST_URI_METHOD.value) ?: "get"
 
-        var httpMethod = try {
+        val httpMethod = try {
             determineHttpMethod(requestUriMethod)
         } catch (e: IllegalArgumentException) {
             throw OpenID4VPExceptions.InvalidData(
@@ -393,7 +393,7 @@ abstract class ClientIdPrefixBasedAuthorizationRequestHandler(
             .setResponseUrl(authorizationRequestParameters, setResponseUri)
     }
 
-    open fun validateAndParseRequestFields() {
+    fun validateAndParseRequestFields() {
         if (authorizationRequestParameters.containsKey(TRANSACTION_DATA.value)) {
             throw OpenID4VPExceptions.InvalidTransactionData(
                 "Invalid Request: transaction_data is not supported in the authorization request",

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandler.kt
@@ -52,8 +52,7 @@ class PreRegisteredSchemeAuthorizationRequestHandler(
     override fun validateClientId() {
         if (!walletConfig.validateTrustedVerifier) return
 
-        val clientId = getStringValue(authorizationRequestParameters, CLIENT_ID.value)!!
-        if (walletConfig.trustedVerifiers.none { it.clientId == clientId }) {
+        if (walletConfig.trustedVerifiers.none { it.clientId == super.clientId }) {
             throw InvalidVerifier(
                 "Verifier is not trusted by the wallet",
                 className
@@ -67,8 +66,7 @@ class PreRegisteredSchemeAuthorizationRequestHandler(
 
     override fun isUnsignedRequestSupported(): Boolean {
         if (walletConfig.validateTrustedVerifier) {
-            val clientId = getStringValue(authorizationRequestParameters, CLIENT_ID.value)!!
-            val preRegisteredVerifier = verifier(clientId)
+            val preRegisteredVerifier = verifier(super.clientId)
 
             return preRegisteredVerifier.allowUnsignedRequest
         }
@@ -84,9 +82,7 @@ class PreRegisteredSchemeAuthorizationRequestHandler(
         algorithm: SignatureAlgorithm,
         kid: String?,
     ): PublicKey {
-        val clientId = getStringValue(authorizationRequestParameters, CLIENT_ID.value)
-
-        val verifier = walletConfig.trustedVerifiers.firstOrNull { it.clientId == clientId }
+        val verifier = walletConfig.trustedVerifiers.firstOrNull { it.clientId == super.clientId }
             ?: throw OpenID4VPExceptions.PublicKeyResolutionFailed(
                 "Public key extraction failed for keyId = $kid, algorithm: ${algorithm.name}",
                 className,
@@ -186,10 +182,15 @@ class PreRegisteredSchemeAuthorizationRequestHandler(
 
     override fun validateClientAuthenticity() {
         if (walletConfig.validateTrustedVerifier) {
-            val clientId = getStringValue(authorizationRequestParameters, CLIENT_ID.value)!!
-            val responseUri = getStringValue(authorizationRequestParameters, RESPONSE_URI.value)!!
+            val responseUri = getStringValue(authorizationRequestParameters, RESPONSE_URI.value)
+                ?: throw OpenID4VPExceptions.MissingInput(
+                    fieldPath = RESPONSE_URI.value,
+                    message = "",
+                    className = className,
+                    notifyVerifier = false
+                )
 
-            val preRegisteredVerifier = verifier(clientId)
+            val preRegisteredVerifier = verifier(super.clientId)
 
             if (!preRegisteredVerifier.responseUris.contains(responseUri)) {
                 throw InvalidVerifier(

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandler.kt
@@ -184,7 +184,7 @@ class PreRegisteredSchemeAuthorizationRequestHandler(
         return walletConfig.toWalletMetadata(specVersion)
     }
 
-    override fun validateAndParseRequestFields() {
+    override fun validateClientAuthenticity() {
         if (walletConfig.validateTrustedVerifier) {
             val clientId = getStringValue(authorizationRequestParameters, CLIENT_ID.value)!!
             val responseUri = getStringValue(authorizationRequestParameters, RESPONSE_URI.value)!!
@@ -198,8 +198,6 @@ class PreRegisteredSchemeAuthorizationRequestHandler(
                 )
             }
         }
-
-        super.validateAndParseRequestFields()
     }
 
     private fun verifier(clientId: String): Verifier {

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.kt
@@ -69,7 +69,7 @@ class RedirectUriPrefixAuthorizationRequestHandler(
              IAR_POST.value, IAR_POST_JWT.value -> {
                  logger.info("IAR_POST or IAR_POST_JWT response_mode is used")
              }
-            else -> throw OpenID4VPExceptions.InvalidData("Given response_mode is not supported", className)
+            else -> throw OpenID4VPExceptions.InvalidData("Given response_mode - $responseMode is not supported", className)
         }
     }
 

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.kt
@@ -59,8 +59,7 @@ class RedirectUriPrefixAuthorizationRequestHandler(
         return walletConfig.toWalletMetadata(specVersion, true)
     }
 
-    override fun validateAndParseRequestFields() {
-        super.validateAndParseRequestFields()
+    override fun validateClientAuthenticity() {
         val responseMode = getStringValue(authorizationRequestParameters, RESPONSE_MODE.value) ?:
         throw OpenID4VPExceptions.MissingInput(listOf(RESPONSE_MODE.value), "", className)
          when (responseMode) {
@@ -78,6 +77,10 @@ class RedirectUriPrefixAuthorizationRequestHandler(
         val responseUri = getStringValue(authRequestParam, RESPONSE_URI.value)
         validate(RESPONSE_URI.value, responseUri, className)
         if (authRequestParam[RESPONSE_URI.value] != extractClientIdPartOnly(authRequestParam))
-            throw OpenID4VPExceptions.InvalidData("${RESPONSE_URI.value} should be equal to client_id for given client_id_prefix", className)
+            throw OpenID4VPExceptions.InvalidData(
+                "${RESPONSE_URI.value} should be equal to client_id for given client_id_prefix",
+                className,
+                notifyVerifier = false
+            )
     }
 }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/exceptions/openId4VPExceptions.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/exceptions/openId4VPExceptions.kt
@@ -101,11 +101,13 @@ sealed class OpenID4VPExceptions(
     class InvalidData(
         message: String,
         className: String,
-        code: String? = null
+        code: String? = null,
+        notifyVerifier: Boolean = true
     ) : OpenID4VPExceptions(
         errorCode = code ?: INVALID_REQUEST,
         message = message,
-        className = className
+        className = className,
+        notifyVerifier = notifyVerifier
     )
 
 

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/ResponseModeBasedHandlerFactory.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/ResponseModeBasedHandlerFactory.kt
@@ -13,6 +13,6 @@ object ResponseModeBasedHandlerFactory {
             DIRECT_POST.value, IAR_POST.value -> DirectPostResponseModeHandler()
             DIRECT_POST_JWT.value, IAR_POST_JWT.value -> DirectPostJwtResponseModeHandler()
             else ->
-                throw  OpenID4VPExceptions.InvalidData("Given response_mode is not supported", className)
+                throw  OpenID4VPExceptions.InvalidData("Given response_mode - $responseMode is not supported", className)
         }
 }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
@@ -490,7 +490,7 @@ class AuthorizationRequestTest {
         val encodedAuthorizationRequest =
             createUrlEncodedData(authorizationRequestParamsMap,false , REDIRECT_URI)
 
-        expectedExceptionMessage = "Given response_mode is not supported"
+        expectedExceptionMessage = "Given response_mode - wrong input is not supported"
         actualException = assertFailsWith<OpenID4VPExceptions.InvalidData> {
             openID4VP.authenticateVerifier(
                 encodedAuthorizationRequest

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandlerTest.kt
@@ -237,7 +237,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
         )
 
         val exception = assertFailsWith<Exception> {
-            handler.validateAndParseRequestFields()
+            handler.validateClientAuthenticity()
         }
         assertTrue(exception.message?.contains("Verifier is not trusted") == true)
     }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandlerTest.kt
@@ -7,6 +7,7 @@ import io.mosip.openID4VP.authorizationRequest.Verifier
 import io.mosip.openID4VP.authorizationRequest.WalletConfig
 import io.mosip.openID4VP.authorizationRequest.clientMetadata.Jwk
 import io.mosip.openID4VP.authorizationRequest.clientMetadata.Jwks
+import io.mosip.openID4VP.common.OpenID4VPErrorCodes
 import io.mosip.openID4VP.common.resolveJwksFromUri
 import io.mosip.openID4VP.constants.ClientIdPrefix
 import io.mosip.openID4VP.constants.SignatureAlgorithm
@@ -201,7 +202,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
         val exception = assertFailsWith<OpenID4VPExceptions.InvalidData> {
             handler.setResponseUrl()
         }
-        assertTrue(exception.message?.contains("redirect_uri should not be present") == true)
+        assertOpenId4VPException(exception,"redirect_uri should not be present for given response_mode", OpenID4VPErrorCodes.INVALID_REQUEST)
     }
 
     @Test
@@ -220,11 +221,11 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
         val exception = assertFailsWith<OpenID4VPExceptions.InvalidData> {
             handler.setResponseUrl()
         }
-        assertTrue(exception.message?.contains("redirect_uri should not be present") == true)
+        assertOpenId4VPException(exception,"redirect_uri should not be present for given response_mode", OpenID4VPErrorCodes.INVALID_REQUEST)
     }
 
     @Test
-    fun `validateAndParseRequestFields should throw exception when response URI is not trusted`() {
+    fun `validateClientAuthenticity should throw exception when response URI is not trusted`() {
         authorizationRequestParameters[RESPONSE_URI.value] =
             "https://untrusted.verifier.com/response"
         val handler = PreRegisteredSchemeAuthorizationRequestHandler(
@@ -236,14 +237,32 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             walletNonce
         )
 
-        val exception = assertFailsWith<Exception> {
+        val exception = assertFailsWith<OpenID4VPExceptions> {
             handler.validateClientAuthenticity()
         }
-        assertTrue(exception.message?.contains("Verifier is not trusted") == true)
+        assertOpenId4VPException(exception,"Verifier is not trusted by the wallet", OpenID4VPErrorCodes.INVALID_CLIENT)
     }
 
     @Test
-    fun `validateAndParseRequestFields should skip validation when validatePreRegisteredVerifier is false`() {
+    fun `validateClientAuthenticity should throw missing input when response_uri is absent`() {
+        authorizationRequestParameters.remove(RESPONSE_URI.value)
+        val handler = PreRegisteredSchemeAuthorizationRequestHandler(
+            validClientId,
+            SpecVersion.DRAFT_23,
+            authorizationRequestParameters,
+            walletConfig,
+            setResponseUri,
+            walletNonce
+        )
+
+        val exception = assertFailsWith<OpenID4VPExceptions.MissingInput> {
+            handler.validateClientAuthenticity()
+        }
+        assertOpenId4VPException(exception,"Missing Input: response_uri param is required", OpenID4VPErrorCodes.INVALID_REQUEST)
+    }
+
+    @Test
+    fun `validateClientAuthenticity should skip validation when validateTrustedVerifier is false`() {
         authorizationRequestParameters[RESPONSE_URI.value] =
             "https://untrusted.verifier.com/response"
         val handler = PreRegisteredSchemeAuthorizationRequestHandler(
@@ -261,7 +280,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
         )
 
         try {
-            handler.validateAndParseRequestFields()
+            handler.validateClientAuthenticity()
         } catch (e: Throwable) {
             fail("Expected no exception, but got: ${e.message}")
         }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriSchemeAuthorizationRequestHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriSchemeAuthorizationRequestHandlerTest.kt
@@ -223,7 +223,7 @@ class RedirectUriSchemeAuthorizationRequestHandlerTest {
         val modifiedParams = authorizationRequestParameters.toMutableMap()
         modifiedParams.remove(RESPONSE_URI.value)
         val exception = assertFailsWith<OpenID4VPExceptions.MissingInput> {
-            createHandler(modifiedParams).validateAndParseRequestFields()
+            createHandler(modifiedParams).validateClientAuthenticity()
         }
         assertTrue(exception.message?.contains("response_uri") == true)
     }
@@ -233,7 +233,7 @@ class RedirectUriSchemeAuthorizationRequestHandlerTest {
         val modifiedParams = authorizationRequestParameters.toMutableMap()
         modifiedParams[RESPONSE_URI.value] = "https://different-domain.com/response"
         val exception = assertFailsWith<OpenID4VPExceptions.InvalidData> {
-            createHandler(modifiedParams).validateAndParseRequestFields()
+            createHandler(modifiedParams).validateClientAuthenticity()
         }
         assertTrue(exception.message?.contains("response_uri should be equal to client_id") == true)
     }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriSchemeAuthorizationRequestHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriSchemeAuthorizationRequestHandlerTest.kt
@@ -12,6 +12,7 @@ import io.mosip.openID4VP.constants.SpecVersion
 import io.mosip.openID4VP.constants.VPFormatType
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.testData.assertDoesNotThrow
+import io.mosip.openID4VP.testData.assertOpenId4VPException
 import io.mosip.openID4VP.testData.clientMetadataString
 import io.mosip.openID4VP.testData.presentationDefinitionString
 import io.mosip.openID4VP.testData.responseUrl
@@ -180,7 +181,11 @@ class RedirectUriSchemeAuthorizationRequestHandlerTest {
         val exception = assertFailsWith<OpenID4VPExceptions.InvalidData> {
             createHandler(modifiedParams).validateAndParseRequestFields()
         }
-        assertTrue(exception.message?.contains("Given response_mode is not supported") == true)
+        assertOpenId4VPException(
+            exception,
+            "Given response_mode - unsupported_mode is not supported",
+            "invalid_request"
+        )
     }
 
     @Test

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/responseModeHandler/ResponseModeBasedHandlerFactoryTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/responseModeHandler/ResponseModeBasedHandlerFactoryTest.kt
@@ -61,66 +61,6 @@ class ResponseModeBasedHandlerFactoryTest {
     }
 
     @Test
-    fun `get should throw InvalidData exception for unsupported response mode`() {
-        val unsupportedMode = "unsupported_mode"
-
-        val exception = assertFailsWith<InvalidData> {
-            ResponseModeBasedHandlerFactory.get(unsupportedMode)
-        }
-
-        assertEquals("Given response_mode is not supported", exception.message)
-    }
-
-    @Test
-    fun `get should throw InvalidData exception for null response mode`() {
-        val exception = assertFailsWith<InvalidData> {
-            ResponseModeBasedHandlerFactory.get("null")
-        }
-
-        assertEquals("Given response_mode is not supported", exception.message)
-    }
-
-    @Test
-    fun `get should throw InvalidData exception for empty response mode`() {
-        val exception = assertFailsWith<InvalidData> {
-            ResponseModeBasedHandlerFactory.get("")
-        }
-
-        assertEquals("Given response_mode is not supported", exception.message)
-    }
-
-    @Test
-    fun `get should throw InvalidData exception for blank response mode`() {
-        val exception = assertFailsWith<InvalidData> {
-            ResponseModeBasedHandlerFactory.get("   ")
-        }
-
-        assertEquals("Given response_mode is not supported", exception.message)
-    }
-
-    @Test
-    fun `get should be case sensitive for response modes`() {
-        val upperCaseMode = ResponseMode.DIRECT_POST.value.uppercase()
-
-        val exception = assertFailsWith<InvalidData> {
-            ResponseModeBasedHandlerFactory.get(upperCaseMode)
-        }
-
-        assertEquals("Given response_mode is not supported", exception.message)
-    }
-
-    @Test
-    fun `get should handle response mode with extra whitespace`() {
-        val modeWithSpaces = " ${ResponseMode.DIRECT_POST.value} "
-
-        val exception = assertFailsWith<InvalidData> {
-            ResponseModeBasedHandlerFactory.get(modeWithSpaces)
-        }
-
-        assertEquals("Given response_mode is not supported", exception.message)
-    }
-
-    @Test
     fun `get should validate all supported response mode constants`() {
         // Test all direct_post variants
         val directPostHandler = ResponseModeBasedHandlerFactory.get("direct_post")
@@ -138,8 +78,14 @@ class ResponseModeBasedHandlerFactoryTest {
     }
 
     @Test
-    fun `get should handle similar but incorrect response modes`() {
+    fun `should throw InvalidData exception for unsupported or invalid response mode`() {
         val similarModes = listOf(
+            "null",
+            "",
+            "   ",
+            "unsupported_mode",
+            "DIRECT_POST",
+            " direct_post ",      // with space
             "direct-post",      // dash instead of underscore
             "directpost",       // no separator
             "direct_post_jwt",  // underscore instead of dot
@@ -153,7 +99,7 @@ class ResponseModeBasedHandlerFactoryTest {
             val exception = assertFailsWith<InvalidData> {
                 ResponseModeBasedHandlerFactory.get(mode)
             }
-            assertEquals("Given response_mode is not supported", exception.message)
+            assertEquals("Given response_mode - $mode is not supported", exception.message)
         }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/inji/inji-wallet/issues/2522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Strengthened authorization request processing by adding an explicit client authenticity validation step.
  - Improved trusted-verifier enforcement for pre-registered and redirect-uri prefix flows (including response URI trust checks).

- **Bug Fixes**
  - Unsupported `response_mode` errors now include the specific invalid value.
  - Enhanced validation outcomes for missing `response_uri` and untrusted verifiers, with consistent error codes/messages.
  - Improved control of verifier notification behavior for certain validation failures.

- **Tests**
  - Updated authorization and response-mode tests to assert structured error codes/messages and added coverage for missing `response_uri`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->