### PR TITLE
inji-wallet/issues/2541 fix: mapping of JWS alg as per holder key for ldp_vp construction

### DIFF
--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/unsignedVPToken/types/ldp/UnsignedLdpVPTokenBuilder.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/unsignedVPToken/types/ldp/UnsignedLdpVPTokenBuilder.kt
@@ -152,7 +152,7 @@ internal class UnsignedLdpVPTokenBuilder(
             LdpVPToken::class.java.simpleName
         )
 
-        val cryptoAlgorithm = resolveJWSAlgorithm(holder)
+        val cryptoAlgorithm = resolveJWSAlgorithm(holder, className)
         val canonicalDataBase64Url =
             URDNA2015Canonicalization.canonicalize(vpTokenSigningPayloadString)
 

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/unsignedVPToken/types/ldp/UnsignedLdpVPTokenBuilder.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/unsignedVPToken/types/ldp/UnsignedLdpVPTokenBuilder.kt
@@ -15,12 +15,12 @@ import io.mosip.openID4VP.authorizationResponse.vpToken.VPToken
 import io.mosip.openID4VP.authorizationResponse.vpToken.getMatchingCredentialQuery
 import io.mosip.openID4VP.authorizationResponse.vpToken.types.ldp.LdpVPToken
 import io.mosip.openID4VP.authorizationResponse.vpToken.types.ldp.Proof
-import io.mosip.openID4VP.common.LdpKeyResolver
 import io.mosip.openID4VP.common.URDNA2015Canonicalization
 import io.mosip.openID4VP.common.UUIDGenerator
 import io.mosip.openID4VP.common.decodeFromBase64Url
 import io.mosip.openID4VP.common.encodeToBase64Url
 import io.mosip.openID4VP.common.encodeToJsonString
+import io.mosip.openID4VP.common.resolveJWSAlgorithm
 import io.mosip.openID4VP.constants.FormatType
 import io.mosip.openID4VP.constants.SignatureSuiteAlgorithm.Ed25519Signature2018
 import io.mosip.openID4VP.constants.SignatureSuiteAlgorithm.Ed25519Signature2020
@@ -152,7 +152,7 @@ internal class UnsignedLdpVPTokenBuilder(
             LdpVPToken::class.java.simpleName
         )
 
-        val cryptoAlgorithm = LdpKeyResolver.resolveJWSAlgorithm(holder)
+        val cryptoAlgorithm = resolveJWSAlgorithm(holder)
         val canonicalDataBase64Url =
             URDNA2015Canonicalization.canonicalize(vpTokenSigningPayloadString)
 

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
@@ -1,6 +1,7 @@
 package io.mosip.openID4VP.common
 
 import co.nstant.`in`.cbor.CborDecoder
+import co.nstant.`in`.cbor.model.Array
 import co.nstant.`in`.cbor.model.ByteString
 import co.nstant.`in`.cbor.model.NegativeInteger
 import co.nstant.`in`.cbor.model.UnicodeString
@@ -9,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.jwk.Curve
 import io.mosip.openID4VP.authorizationRequest.clientMetadata.Jwks
 import io.mosip.openID4VP.authorizationResponse.presentationSubmission.PathNested
 import io.mosip.openID4VP.constants.FormatType
@@ -22,7 +25,11 @@ import io.mosip.vercred.vcverifier.keyResolver.types.did.DidPublicKeyResolver
 import java.io.ByteArrayInputStream
 import java.math.BigInteger
 import java.security.MessageDigest
+import java.security.PublicKey
 import java.security.SecureRandom
+import java.security.interfaces.ECPublicKey
+import java.security.interfaces.RSAPublicKey
+
 
 // RFC 3986 (https://www.rfc-editor.org/rfc/rfc3986#section-3) https URI
 private const val URL_PATTERN =
@@ -166,7 +173,7 @@ private fun extractMdocKeyReferenceAndAlg(
         ?: throw InvalidData("issuerSigned missing", className)
 
     val issuerAuthArray =
-        issuerSigned[UnicodeString("issuerAuth")] as? co.nstant.`in`.cbor.model.Array
+        issuerSigned[UnicodeString("issuerAuth")] as? Array
             ?: throw InvalidData("issuerAuth not COSE_Sign1", className)
 
     val payloadBytes = issuerAuthArray.dataItems[2] as? ByteString
@@ -300,17 +307,44 @@ fun encodeToMultibaseBase58btc(bytes: ByteArray): String {
     return "z" + sb.reverse().toString()
 }
 
-object LdpKeyResolver {
-    fun resolveJWSAlgorithm(holderUri: String): String {
-        val publicKey = DidPublicKeyResolver().resolve(holderUri.trimEnd('='), null)
-        return when (publicKey.algorithm) {
-            "Ed25519" -> "EdDSA"
-            "EC" -> "ES256"
-            "RSA" -> "RS256"
-            else -> throw InvalidData(
-                "Unsupported key algorithm ${publicKey.algorithm}",
-                "Utils"
-            )
+fun resolveJWSAlgorithm(didUrl: String): String {
+    return try {
+        val rawKey: PublicKey = DidPublicKeyResolver().resolve(didUrl.trimEnd('='), null)
+        val jwsAlgorithm = when (rawKey) {
+            is ECPublicKey -> {
+                val curve = Curve.forECParameterSpec(rawKey.params)
+                    ?: throw IllegalArgumentException("Unknown or unsupported EC curve parameters")
+
+                when (curve) {
+                    Curve.SECP256K1 -> JWSAlgorithm.ES256K
+                    Curve.P_256 -> JWSAlgorithm.ES256
+                    Curve.P_384 -> JWSAlgorithm.ES384
+                    Curve.P_521 -> JWSAlgorithm.ES512
+                    else -> throw IllegalArgumentException("Unsupported EC curve: ${curve.name}")
+                }
+            }
+
+            is RSAPublicKey -> JWSAlgorithm.RS256
+
+            else -> {
+                if (rawKey.algorithm.equals(
+                        "Ed25519",
+                        ignoreCase = true
+                    ) || rawKey.algorithm.equals("EdDSA", ignoreCase = true)
+                ) {
+                    JWSAlgorithm.EdDSA
+                } else {
+                    throw IllegalArgumentException("Unsupported key type: ${rawKey.javaClass.simpleName}")
+                }
+            }
         }
+
+        jwsAlgorithm.name
+    } catch (e: Exception) {
+        throw InvalidData(
+            message = "Unable to resolve a supported JWS algorithm for key",
+            className = "Utils",
+            cause = e
+        )
     }
 }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/common/Utils.kt
@@ -307,7 +307,7 @@ fun encodeToMultibaseBase58btc(bytes: ByteArray): String {
     return "z" + sb.reverse().toString()
 }
 
-fun resolveJWSAlgorithm(didUrl: String): String {
+fun resolveJWSAlgorithm(didUrl: String, className: String = "Utils"): String {
     return try {
         val rawKey: PublicKey = DidPublicKeyResolver().resolve(didUrl.trimEnd('='), null)
         val jwsAlgorithm = when (rawKey) {
@@ -343,7 +343,7 @@ fun resolveJWSAlgorithm(didUrl: String): String {
     } catch (e: Exception) {
         throw InvalidData(
             message = "Unable to resolve a supported JWS algorithm for key",
-            className = "Utils",
+            className = className,
             cause = e
         )
     }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/exceptions/openId4VPExceptions.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/exceptions/openId4VPExceptions.kt
@@ -102,12 +102,14 @@ sealed class OpenID4VPExceptions(
         message: String,
         className: String,
         code: String? = null,
-        notifyVerifier: Boolean = true
+        notifyVerifier: Boolean = true,
+        cause: Throwable? = null
     ) : OpenID4VPExceptions(
         errorCode = code ?: INVALID_REQUEST,
         message = message,
         className = className,
-        notifyVerifier = notifyVerifier
+        notifyVerifier = notifyVerifier,
+        cause = cause
     )
 
 

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/unsignedVPToken/types/ldp/UnsignedLdpVPTokenBuilderTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/unsignedVPToken/types/ldp/UnsignedLdpVPTokenBuilderTest.kt
@@ -13,11 +13,11 @@ import io.mosip.openID4VP.authorizationRequest.presentationDefinition.Presentati
 import io.mosip.openID4VP.authorizationResponse.CredentialInputDescriptorMapping
 import io.mosip.openID4VP.authorizationResponse.CredentialToCredentialQueryIdMapping
 import io.mosip.openID4VP.authorizationResponse.vpToken.types.ldp.LdpVPToken
-import io.mosip.openID4VP.common.LdpKeyResolver
 import io.mosip.openID4VP.common.URDNA2015Canonicalization
 import io.mosip.openID4VP.common.decodeFromBase64Url
 import io.mosip.openID4VP.common.encodeToBase64Url
 import io.mosip.openID4VP.common.encodeToJsonString
+import io.mosip.openID4VP.common.resolveJWSAlgorithm
 import io.mosip.openID4VP.constants.FormatType
 import io.mosip.openID4VP.constants.SignatureSuiteAlgorithm
 import io.mosip.openID4VP.constants.SpecVersion
@@ -104,8 +104,8 @@ class UnsignedLdpVPTokenBuilderTest {
         mockkObject(URDNA2015Canonicalization)
         every { URDNA2015Canonicalization.canonicalize(any()) } returns mockCanonicalizedData
 
-        mockkObject(LdpKeyResolver)
-        every { LdpKeyResolver.resolveJWSAlgorithm(any()) } returns "EdDSA"
+        mockkStatic(::resolveJWSAlgorithm)
+        every { resolveJWSAlgorithm(any()) } returns "EdDSA"
 
         mockkStatic(::decodeFromBase64Url)
         every { decodeFromBase64Url(any()) } answers {

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/unsignedVPToken/types/ldp/UnsignedLdpVPTokenBuilderTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/unsignedVPToken/types/ldp/UnsignedLdpVPTokenBuilderTest.kt
@@ -105,7 +105,7 @@ class UnsignedLdpVPTokenBuilderTest {
         every { URDNA2015Canonicalization.canonicalize(any()) } returns mockCanonicalizedData
 
         mockkStatic(::resolveJWSAlgorithm)
-        every { resolveJWSAlgorithm(any()) } returns "EdDSA"
+        every { resolveJWSAlgorithm(any(), any()) } returns "EdDSA"
 
         mockkStatic(::decodeFromBase64Url)
         every { decodeFromBase64Url(any()) } answers {

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/common/UtilsTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/common/UtilsTest.kt
@@ -1,11 +1,14 @@
 package io.mosip.openID4VP.common
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import io.mockk.every
-import io.mockk.mockkObject
+import com.nimbusds.jose.jwk.Curve
+import io.mockk.*
 import io.mosip.openID4VP.constants.HttpMethod
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.networkManager.NetworkManagerClient
 import io.mosip.openID4VP.networkManager.NetworkResponse
+import io.mosip.openID4VP.testData.assertOpenId4VPException
+import io.mosip.vercred.vcverifier.keyResolver.types.did.DidPublicKeyResolver
 import kotlin.test.*
 
 class UtilsTest {
@@ -205,5 +208,101 @@ class UtilsTest {
         val publicKey = resolveJwksFromUri(jwksUri, keyId)
 
         assertNotNull(publicKey)
+    }
+
+    @Test
+    fun `resolveJWSAlgorithm should return correct algorithm for various key types`() {
+        data class TestCase(
+            val description: String,
+            val keyType: String,
+            val expectedAlgo: String,
+            val setupMock: () -> java.security.PublicKey
+        )
+
+        val testCases = listOf(
+            TestCase("RSA key", "RSA", "RS256") {
+                mockk<java.security.interfaces.RSAPublicKey>().apply {
+                    every { algorithm } returns "RSA"
+                }
+            },
+            TestCase("Ed25519 key", "Ed25519", "EdDSA") {
+                mockk<java.security.PublicKey>().apply {
+                    every { algorithm } returns "Ed25519"
+                }
+            },
+            TestCase("P-256 EC key", "EC", "ES256") {
+                mockk<java.security.interfaces.ECPublicKey>().apply {
+                    every { algorithm } returns "EC"
+                    every { params } returns Curve.P_256.toECParameterSpec()
+                }
+            },
+            TestCase("P-384 EC key", "EC", "ES384") {
+                mockk<java.security.interfaces.ECPublicKey>().apply {
+                    every { algorithm } returns "EC"
+                    every { params } returns Curve.P_384.toECParameterSpec()
+                }
+            },
+            TestCase("P-521 EC key", "EC", "ES512") {
+                mockk<java.security.interfaces.ECPublicKey>().apply {
+                    every { algorithm } returns "EC"
+                    every { params } returns Curve.P_521.toECParameterSpec()
+                }
+            },
+            TestCase("secp256k1 EC key", "EC", "ES256K") {
+                mockk<java.security.interfaces.ECPublicKey>().apply {
+                    every { algorithm } returns "EC"
+                    every { params } returns Curve.SECP256K1.toECParameterSpec()
+                }
+            }
+        )
+
+        mockkConstructor(DidPublicKeyResolver::class)
+
+        try {
+            testCases.forEach { testCase ->
+                val mockPublicKey = testCase.setupMock()
+
+                every {
+                    anyConstructed<DidPublicKeyResolver>().resolve(any(), any())
+                } returns mockPublicKey
+
+                val result = resolveJWSAlgorithm("did:test")
+                assertEquals(
+                    testCase.expectedAlgo,
+                    result,
+                    "Failed for ${testCase.description}: expected ${testCase.expectedAlgo} but got $result"
+                )
+            }
+        } finally {
+            unmockkConstructor(DidPublicKeyResolver::class)
+        }
+    }
+
+    @Test
+    fun `resolveJWSAlgorithm should throw InvalidData for unsupported key algorithm`() {
+        val unsupportedAlgorithms = listOf("DH")
+
+        mockkConstructor(DidPublicKeyResolver::class)
+
+        try {
+            unsupportedAlgorithms.forEach { algorithm ->
+                val mockPublicKey = mockk<java.security.PublicKey>().apply {
+                    every { this@apply.algorithm } returns algorithm
+                }
+
+                every {
+                    anyConstructed<DidPublicKeyResolver>().resolve(any(), any())
+                } returns mockPublicKey
+
+                val exception = assertFailsWith<OpenID4VPExceptions.InvalidData> {
+                    resolveJWSAlgorithm("did:test:$algorithm")
+                }
+
+                assertOpenId4VPException(exception,"Unable to resolve a supported JWS algorithm for key",
+                    OpenID4VPErrorCodes.INVALID_REQUEST)
+            }
+        } finally {
+            unmockkConstructor(DidPublicKeyResolver::class)
+        }
     }
 }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/common/UtilsTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/common/UtilsTest.kt
@@ -3,6 +3,7 @@ package io.mosip.openID4VP.common
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.nimbusds.jose.jwk.Curve
 import io.mockk.*
+import io.mosip.openID4VP.common.OpenID4VPErrorCodes
 import io.mosip.openID4VP.constants.HttpMethod
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.networkManager.NetworkManagerClient
@@ -10,6 +11,14 @@ import io.mosip.openID4VP.networkManager.NetworkResponse
 import io.mosip.openID4VP.testData.assertOpenId4VPException
 import io.mosip.vercred.vcverifier.keyResolver.types.did.DidPublicKeyResolver
 import kotlin.test.*
+import java.security.PublicKey
+
+// Test helper: Creates a PublicKey with predictable class name for testing unsupported algorithms
+class TestPublicKey(val keyAlgorithm: String) : PublicKey {
+    override fun getAlgorithm(): String = keyAlgorithm
+    override fun getEncoded(): ByteArray = byteArrayOf()
+    override fun getFormat(): String = "TEST"
+}
 
 class UtilsTest {
 
@@ -280,29 +289,75 @@ class UtilsTest {
 
     @Test
     fun `resolveJWSAlgorithm should throw InvalidData for unsupported key algorithm`() {
-        val unsupportedAlgorithms = listOf("DH")
-
         mockkConstructor(DidPublicKeyResolver::class)
+        mockkStatic(Curve::class)
 
         try {
-            unsupportedAlgorithms.forEach { algorithm ->
-                val mockPublicKey = mockk<java.security.PublicKey>().apply {
-                    every { this@apply.algorithm } returns algorithm
-                }
+            // Test case 1: Generic unsupported key algorithm (DH) - use real TestPublicKey for stable class name
+            every {
+                anyConstructed<DidPublicKeyResolver>().resolve(any(), any())
+            } returns TestPublicKey("DH")
 
-                every {
-                    anyConstructed<DidPublicKeyResolver>().resolve(any(), any())
-                } returns mockPublicKey
-
-                val exception = assertFailsWith<OpenID4VPExceptions.InvalidData> {
-                    resolveJWSAlgorithm("did:test:$algorithm")
-                }
-
-                assertOpenId4VPException(exception,"Unable to resolve a supported JWS algorithm for key",
-                    OpenID4VPErrorCodes.INVALID_REQUEST)
+            val dhException = assertFailsWith<OpenID4VPExceptions.InvalidData> {
+                resolveJWSAlgorithm("did:test:dh", "TestClass")
             }
+            assertOpenId4VPException(
+                dhException,
+                "Unable to resolve a supported JWS algorithm for key",
+                OpenID4VPErrorCodes.INVALID_REQUEST,
+                expectedUnderlyingErrorMessage = "Unsupported key type: TestPublicKey"
+            )
+
+            // Test case 2: EC key with unsupported/unmapped curve (Curve.forECParameterSpec returns null)
+            val mockECKeyUnmappedCurve = mockk<java.security.interfaces.ECPublicKey>().apply {
+                every { algorithm } returns "EC"
+                every { params } returns mockk<java.security.spec.ECParameterSpec>()
+            }
+            every {
+                anyConstructed<DidPublicKeyResolver>().resolve(any(), any())
+            } returns mockECKeyUnmappedCurve
+            every {
+                Curve.forECParameterSpec(any())
+            } returns null
+
+            val ecNullCurveException = assertFailsWith<OpenID4VPExceptions.InvalidData> {
+                resolveJWSAlgorithm("did:test:ec-null-curve", "TestClass")
+            }
+            assertOpenId4VPException(
+                ecNullCurveException,
+                "Unable to resolve a supported JWS algorithm for key",
+                OpenID4VPErrorCodes.INVALID_REQUEST,
+                expectedUnderlyingErrorMessage = "Unknown or unsupported EC curve parameters"
+            )
+
+            // Test case 3: EC key with resolved curve but unsupported in the when statement
+            val mockECKeyUnsupportedCurve = mockk<java.security.interfaces.ECPublicKey>().apply {
+                every { algorithm } returns "EC"
+                every { params } returns mockk<java.security.spec.ECParameterSpec>()
+            }
+            every {
+                anyConstructed<DidPublicKeyResolver>().resolve(any(), any())
+            } returns mockECKeyUnsupportedCurve
+
+            val mockUnsupportedCurve = mockk<Curve>().apply {
+                every { name } returns "UNSUPPORTED_CURVE"
+            }
+            every {
+                Curve.forECParameterSpec(any())
+            } returns mockUnsupportedCurve
+
+            val ecUnsupportedCurveException = assertFailsWith<OpenID4VPExceptions.InvalidData> {
+                resolveJWSAlgorithm("did:test:ec-unsupported-curve", "TestClass")
+            }
+            assertOpenId4VPException(
+                ecUnsupportedCurveException,
+                "Unable to resolve a supported JWS algorithm for key",
+                OpenID4VPErrorCodes.INVALID_REQUEST,
+                expectedUnderlyingErrorMessage = "Unsupported EC curve: UNSUPPORTED_CURVE"
+            )
         } finally {
             unmockkConstructor(DidPublicKeyResolver::class)
+            unmockkStatic(Curve::class)
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic selection of JWS algorithms for unsigned LDP VP tokens by analyzing the resolved public key type and elliptic curve.
  * Unsupported or unresolved keys now return clearer structured errors, with underlying causes preserved.

* **Tests**
  * Updated and expanded test coverage to verify correct algorithm mapping for RSA, EdDSA, and multiple EC curves.
  * Added failure-path tests to confirm proper error handling for unsupported keys and unmapped/unsupported curve scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->