### PR TITLE
refactor: udpate license to Apache 2.0

### DIFF
--- a/.github/workflows/android-maven-publish.yml
+++ b/.github/workflows/android-maven-publish.yml
@@ -42,7 +42,7 @@ jobs:
       ANDROID_SERVICE_LOCATION: 'openID4VP'
       GROUP_PATH: ${{ inputs.group_path }}   #dynamic
       JAVA_VERSION: 21
-      LICENSE_NAME: 'MPL-2.0'
+      LICENSE_NAME: 'Apache 2.0'
       RELEASE_TYPE: ${{ inputs.release_type }}
     secrets:
       OSSRH_USER: ${{ secrets.OSSRH_USER }}
@@ -60,7 +60,7 @@ jobs:
       ANDROID_SERVICE_LOCATION: 'openID4VP'
       GROUP_PATH: ${{ inputs.group_path }}   #dynamic
       JAVA_VERSION: 21
-      LICENSE_NAME: 'MPL-2.0'
+      LICENSE_NAME: 'Apache 2.0'
       RELEASE_TYPE: ${{ inputs.release_type }}
       PUBLICATION_TYPE: ${{ inputs.publication_type }}
     secrets:

--- a/kotlin/openID4VP/publish-artifact.gradle
+++ b/kotlin/openID4VP/publish-artifact.gradle
@@ -31,8 +31,8 @@ publishing {
                     asNode().appendNode('description', "Kotlin Library to implement OpenID4VP specification")
 
                     asNode().appendNode('licenses').appendNode('license').with {
-                        appendNode('name', 'MPL-2.0')
-                        appendNode('url', 'https://www.mozilla.org/en-US/MPL/2.0/')
+                        appendNode('name', 'Apache 2.0')
+                        appendNode('url', 'https://www.apache.org/licenses/LICENSE-2.0')
                     }
 
                     asNode().appendNode('scm').with {
@@ -126,8 +126,8 @@ publishing {
                     asNode().appendNode('description', "Kotlin Library to implement OpenID4VP specification")
 
                     asNode().appendNode('licenses').appendNode('license').with {
-                        appendNode('name', 'MPL-2.0')
-                        appendNode('url', 'https://www.mozilla.org/en-US/MPL/2.0/')
+                        appendNode('name', 'Apache 2.0')
+                        appendNode('url', 'https://www.apache.org/licenses/LICENSE-2.0')
                     }
 
                     asNode().appendNode('developers').appendNode('developer').with {


### PR DESCRIPTION
Update workflows with Apache License

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated published artifact metadata to identify the project under the Apache License 2.0.
  * Applied the license metadata update consistently to snapshot and release publications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->