### PR TITLE
fix(openid4vp) Kotlin Ignore invalid JWKS in client metadata 

### DIFF
--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/clientMetadata/Jwks.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/clientMetadata/Jwks.kt
@@ -14,8 +14,10 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.jsonObject
+import java.util.logging.Logger
 
 private val className = Jwks::class.simpleName!!
+private val logger = Logger.getLogger(className)
 
 object JwksSerializer : KSerializer<Jwks> {
     override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Jwks") {
@@ -36,8 +38,10 @@ object JwksSerializer : KSerializer<Jwks> {
                 try {
                     jsonDecoder.json.decodeFromJsonElement(Jwk.serializer(), keyElement)
                 } catch (e: OpenID4VPExceptions) {
+                    logger.warning("Ignoring invalid jwk in client_metadata.jwks.keys: ${e.message}")
                     null
                 } catch (e: IllegalArgumentException) {
+                    logger.warning("Ignoring invalid jwk in client_metadata.jwks.keys: ${e.message}")
                     null
                 }
             }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/clientMetadata/Jwks.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/clientMetadata/Jwks.kt
@@ -35,7 +35,9 @@ object JwksSerializer : KSerializer<Jwks> {
             keysElement.mapNotNull { keyElement ->
                 try {
                     jsonDecoder.json.decodeFromJsonElement(Jwk.serializer(), keyElement)
-                } catch (e: Exception) {
+                } catch (e: OpenID4VPExceptions) {
+                    null
+                } catch (e: IllegalArgumentException) {
                     null
                 }
             }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/clientMetadata/Jwks.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/clientMetadata/Jwks.kt
@@ -2,7 +2,6 @@ package io.mosip.openID4VP.authorizationRequest.clientMetadata
 
 import Generated
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.FieldsSerializer
-import io.mosip.openID4VP.common.FieldDeserializer
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -12,6 +11,7 @@ import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.descriptors.element
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.jsonObject
 
@@ -29,15 +29,19 @@ object JwksSerializer : KSerializer<Jwks> {
             throw OpenID4VPExceptions.DeserializationFailure( listOf("jwk"),e.message!!, className )
         }
         val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
-        val deserializer = FieldDeserializer(
-            jsonObject = jsonObject, className = className, parentField = "jwk"
-        )
-        val keys: List<Jwk> = deserializer.deserializeField(
-            key = "keys",
-            fieldType = "List<Jwk>",
-            deserializer = ListSerializer(Jwk.serializer()),
-            isMandatory = false
-        )!!
+
+        val keysElement = jsonObject["keys"]
+        val keys: List<Jwk> = if (keysElement is JsonArray) {
+            keysElement.mapNotNull { keyElement ->
+                try {
+                    jsonDecoder.json.decodeFromJsonElement(Jwk.serializer(), keyElement)
+                } catch (e: Exception) {
+                    null
+                }
+            }
+        } else {
+            emptyList()
+        }
         return Jwks(keys = keys)
     }
 

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/clientMetadata/JwksSerializerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/clientMetadata/JwksSerializerTest.kt
@@ -1,0 +1,62 @@
+package io.mosip.openID4VP.authorizationRequest.clientMetadata
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JwksSerializerTest {
+
+    // https://github.com/inji/inji-wallet/issues/2524
+    // Test: oid4vp-1final-wallet-ignores-unusable-encryption-key
+    @Test
+    fun `should ignore unusable jwks and keep only the usable encryption key`() {
+        val json = """
+            {
+              "keys": [
+                {
+                  "kty": "OKP",
+                  "use": "enc",
+                  "crv": "X25519",
+                  "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
+                  "alg": "ECDH-ES",
+                  "kid": "valid-enc-key"
+                },
+                {
+                  "kty": "AKP",
+                  "alg": "ML-KEM-9999",
+                  "use": "enc",
+                  "kid": "post-quantum-key"
+                },
+                {
+                  "kty": "OIDF-CONFORMANCE-UNSUPPORTED",
+                  "use": "enc",
+                  "kid": "unsupported-key"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val jwks = Json.decodeFromString(JwksSerializer, json)
+
+        assertEquals(1, jwks.keys.size)
+        assertEquals("valid-enc-key", jwks.keys.first().kid)
+    }
+
+    @Test
+    fun `should return empty keys when every key is unusable`() {
+        val json = """
+            { "keys": [ { "kty": "AKP", "alg": "ML-KEM-9999", "use": "enc", "kid": "pq-key" } ] }
+        """.trimIndent()
+
+        val jwks = Json.decodeFromString(JwksSerializer, json)
+
+        assertEquals(0, jwks.keys.size)
+    }
+
+    @Test
+    fun `should return empty keys when keys array is absent`() {
+        val jwks = Json.decodeFromString(JwksSerializer, "{}")
+
+        assertEquals(0, jwks.keys.size)
+    }
+}

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/clientMetadata/JwksSerializerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/clientMetadata/JwksSerializerTest.kt
@@ -24,13 +24,15 @@ class JwksSerializerTest {
                 {
                   "kty": "AKP",
                   "alg": "ML-KEM-9999",
+                  "kid": "unusable-pq-enc-key",
                   "use": "enc",
-                  "kid": "post-quantum-key"
+                  "pub": "Z0FOY29uZm9ybWFuY2UtdGVzdC1wbGFjZWhvbGRlci1wdWJsaWMta2V5"
                 },
                 {
                   "kty": "OIDF-CONFORMANCE-UNSUPPORTED",
-                  "use": "enc",
-                  "kid": "unsupported-key"
+                  "alg": "OIDF-CONFORMANCE-UNSUPPORTED",
+                  "kid": "unusable-unknown-enc-key",
+                  "use": "enc"
                 }
               ]
             }
@@ -45,7 +47,7 @@ class JwksSerializerTest {
     @Test
     fun `should return empty keys when every key is unusable`() {
         val json = """
-            { "keys": [ { "kty": "AKP", "alg": "ML-KEM-9999", "use": "enc", "kid": "pq-key" } ] }
+            { "keys": [ { "kty": "AKP", "alg": "ML-KEM-9999", "kid": "unusable-pq-enc-key", "use": "enc", "pub": "Z0FOY29uZm9ybWFuY2UtdGVzdC1wbGFjZWhvbGRlci1wdWJsaWMta2V5" } ] }
         """.trimIndent()
 
         val jwks = Json.decodeFromString(JwksSerializer, json)

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/clientMetadata/JwksSerializerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/clientMetadata/JwksSerializerTest.kt
@@ -59,4 +59,35 @@ class JwksSerializerTest {
 
         assertEquals(0, jwks.keys.size)
     }
+
+    @Test
+    fun `should return empty keys when keys is present but not an array`() {
+        val jwks = Json.decodeFromString(JwksSerializer, """{ "keys": { "kty": "OKP" } }""")
+
+        assertEquals(0, jwks.keys.size)
+    }
+
+    @Test
+    fun `should ignore entries in keys array that are not json objects`() {
+        val json = """
+            {
+              "keys": [
+                "not-an-object",
+                {
+                  "kty": "OKP",
+                  "use": "enc",
+                  "crv": "X25519",
+                  "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
+                  "alg": "ECDH-ES",
+                  "kid": "valid-enc-key"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val jwks = Json.decodeFromString(JwksSerializer, json)
+
+        assertEquals(1, jwks.keys.size)
+        assertEquals("valid-enc-key", jwks.keys.first().kid)
+    }
 }


### PR DESCRIPTION
@coderabbitai refer this issue link https://github.com/orgs/inji/projects/4/views/19?pane=issue&itemId=211200071&issue=inji%7Cinji-wallet%7C2524
 this pr fixes the issue 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JWKS parsing to ignore invalid or unusable key entries and retain only usable keys.
  * When the `keys` field is missing or not an array, the app now safely treats it as having no keys.
* **Tests**
  * Added coverage for mixed usable/unusable keys, all-unusable key sets, missing `keys`, `keys` not being an array, and ignoring non-object entries within the `keys` array.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->