### PR TITLE
fix(authorization-response): encrypt error responses in direct_post.jwt

### DIFF
--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/OpenID4VP.kt
@@ -7,6 +7,7 @@ import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
 import io.mosip.openID4VP.common.*
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
 import io.mosip.openID4VP.verifier.VerifierResponse
 import io.mosip.openID4VP.wallet.Credential
 
@@ -15,7 +16,7 @@ class OpenID4VP @JvmOverloads constructor(
     private val walletConfig: WalletConfig = WalletConfig()
 ) {
     private var authorizationResponseHandler = AuthorizationResponseHandler(walletConfig = walletConfig)
-    private var responseUri: String? = null
+    private var responseDispatchInfo: ResponseDispatchInfo? = null
     private var walletNonce: String = generateNonce()
     var authorizationRequest: AuthorizationRequest? = null
     private val className = OpenID4VP::class.simpleName.orEmpty()
@@ -27,13 +28,13 @@ class OpenID4VP @JvmOverloads constructor(
         return try {
             walletNonce = generateNonce()
             authorizationRequest = null
-            responseUri = null
+            responseDispatchInfo = null
             authorizationResponseHandler = AuthorizationResponseHandler(walletConfig)
             val authorizationRequest =
                 AuthorizationRequest.validateAndCreateAuthorizationRequest(
                     urlEncodedAuthorizationRequest,
                     walletConfig,
-                    ::setResponseUri,
+                    ::setResponseDispatchInfo,
                     walletNonce
                 )
             this.authorizationRequest = authorizationRequest
@@ -50,13 +51,13 @@ class OpenID4VP @JvmOverloads constructor(
         return try {
             walletNonce = generateNonce()
             this.authorizationRequest = null
-            responseUri = null
+            responseDispatchInfo = null
             authorizationResponseHandler = AuthorizationResponseHandler(walletConfig)
             val validatedAuthorizationRequest =
                 AuthorizationRequest.validateAndCreateAuthorizationRequest(
                     authorizationRequest,
                     walletConfig,
-                    ::setResponseUri,
+                    ::setResponseDispatchInfo,
                     walletNonce
                 )
             this.authorizationRequest = validatedAuthorizationRequest
@@ -74,7 +75,7 @@ class OpenID4VP @JvmOverloads constructor(
             authorizationResponseHandler.constructUnsignedVPToken(
                 selectedCredentials = selectedCredentials,
                 authorizationRequest = authorizationRequest!!,
-                responseUri = responseUri!!,
+                responseUri = responseDispatchInfo!!.responseUrl,
                 nonce = walletNonce
             )
         } catch (exception: OpenID4VPExceptions) {
@@ -92,6 +93,7 @@ class OpenID4VP @JvmOverloads constructor(
             authorizationResponseHandler.constructVPResponse(
                 authorizationRequest = authorizationRequest!!,
                 vpTokenSigningResults = vpTokenSigningResults,
+                dispatchInfo = responseDispatchInfo
             )
         } catch (exception: OpenID4VPExceptions) {
             return constructErrorInfo(exception)
@@ -112,7 +114,7 @@ class OpenID4VP @JvmOverloads constructor(
             authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
                 authorizationRequest = authorizationRequest!!,
                 vpTokenSigningResults = vpTokenSigningResults,
-                responseUri = responseUri!!
+                dispatchInfo = responseDispatchInfo
             )
         } catch (exception: OpenID4VPExceptions) {
             this.safeSendError(exception)
@@ -126,9 +128,10 @@ class OpenID4VP @JvmOverloads constructor(
 
     fun constructErrorInfo(exception: Exception): Map<String, Any> {
         return authorizationResponseHandler.constructAuthorizationErrorResponse(
-            authorizationRequest,
+            responseDispatchInfo,
             exception,
-            walletNonce
+            walletNonce,
+            authorizationRequest
         )
     }
 
@@ -138,14 +141,14 @@ class OpenID4VP @JvmOverloads constructor(
      */
     fun sendErrorInfoToVerifier(exception: Exception): VerifierResponse {
         return authorizationResponseHandler.sendAuthorizationError(
-            responseUri,
+            responseDispatchInfo,
             authorizationRequest,
             exception
         )
     }
 
-    private fun setResponseUri(uri: String) {
-        this.responseUri = uri
+    private fun setResponseDispatchInfo(dispatchInfo: ResponseDispatchInfo) {
+        this.responseDispatchInfo = dispatchInfo
     }
 
     private fun safeSendError(exception: Exception) {

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequest.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequest.kt
@@ -4,6 +4,7 @@ import io.mosip.openID4VP.authorizationRequest.clientMetadata.ClientMetadata
 import io.mosip.openID4VP.authorizationRequest.clientMetadata.ClientMetadataDraft23
 import io.mosip.openID4VP.dcql.query.DCQLQuery
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.PresentationDefinition
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
 
 open class AuthorizationRequest(
     val clientId: String,
@@ -21,14 +22,14 @@ open class AuthorizationRequest(
         fun validateAndCreateAuthorizationRequest(
             authorizationRequest: Map<String, Any>,
             walletConfig: WalletConfig,
-            setResponseUri: (String) -> Unit,
+            setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit,
             walletNonce: String
         ): AuthorizationRequest {
 
             return getAuthorizationRequest(
                 authorizationRequest.toMutableMap(),
                 walletConfig,
-                setResponseUri,
+                setResponseDispatchInfo,
                 walletNonce
             )
         }
@@ -36,7 +37,7 @@ open class AuthorizationRequest(
         fun validateAndCreateAuthorizationRequest(
             urlEncodedAuthorizationRequest: String,
             walletConfig: WalletConfig,
-            setResponseUri: (String) -> Unit,
+            setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit,
             walletNonce: String
         ): AuthorizationRequest {
 
@@ -44,7 +45,7 @@ open class AuthorizationRequest(
             return getAuthorizationRequest(
                 queryParameter.toMutableMap(),
                 walletConfig,
-                setResponseUri,
+                setResponseDispatchInfo,
                 walletNonce
             )
         }
@@ -52,13 +53,13 @@ open class AuthorizationRequest(
         private fun getAuthorizationRequest(
             params: MutableMap<String, Any>,
             walletConfig: WalletConfig,
-            setResponseUri: (String) -> Unit,
+            setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit,
             walletNonce: String
         ): AuthorizationRequest {
             val authorizationRequestHandler = getAuthorizationRequestHandler(
                 params,
                 walletConfig,
-                setResponseUri,
+                setResponseDispatchInfo,
                 walletNonce
             )
             return authorizationRequestHandler.handle()

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestUtils.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestUtils.kt
@@ -10,6 +10,7 @@ import io.mosip.openID4VP.constants.ClientIdScheme
 import io.mosip.openID4VP.constants.ResponseType
 import io.mosip.openID4VP.constants.SpecVersion
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
 import java.net.URI
 import java.net.URLDecoder
 
@@ -18,7 +19,7 @@ private val className = AuthorizationRequest::class.simpleName!!
 fun getAuthorizationRequestHandler(
     authorizationRequestParameters: MutableMap<String, Any>,
     walletConfig: WalletConfig,
-    setResponseUri: (String) -> Unit,
+    setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit,
     walletNonce: String
 ): ClientIdPrefixBasedAuthorizationRequestHandler {
     validate(CLIENT_ID.value, getStringValue(authorizationRequestParameters, CLIENT_ID.value), className)
@@ -37,7 +38,7 @@ fun getAuthorizationRequestHandler(
             specVersion = specVersion,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
         ClientIdPrefix.REDIRECT_URI.value -> RedirectUriPrefixAuthorizationRequestHandler(
@@ -45,7 +46,7 @@ fun getAuthorizationRequestHandler(
             specVersion = specVersion,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
         ClientIdScheme.DID.value, ClientIdPrefix.DECENTRALIZED_IDENTIFIER.value ->
@@ -54,7 +55,7 @@ fun getAuthorizationRequestHandler(
                 specVersion = specVersion,
                 authorizationRequestParameters = authorizationRequestParameters,
                 walletConfig = walletConfig,
-                setResponseUri = setResponseUri,
+                setResponseDispatchInfo = setResponseDispatchInfo,
                 walletNonce = walletNonce
             )
         else -> {
@@ -63,7 +64,7 @@ fun getAuthorizationRequestHandler(
                 specVersion = specVersion,
                 authorizationRequestParameters = authorizationRequestParameters,
                 walletConfig = walletConfig,
-                setResponseUri = setResponseUri,
+                setResponseDispatchInfo = setResponseDispatchInfo,
                 walletNonce = walletNonce
             )
         }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.kt
@@ -49,6 +49,8 @@ import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.jwt.jws.JWSHandler
 import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
 import io.mosip.openID4VP.networkManager.NetworkResponse
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
+import io.mosip.openID4VP.responseModeHandler.ResponseEncryptionSpecification
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandlerFactory
 import java.security.PublicKey
 import java.util.logging.Logger
@@ -60,11 +62,12 @@ abstract class ClientIdPrefixBasedAuthorizationRequestHandler(
     var specVersion: SpecVersion,
     var authorizationRequestParameters: MutableMap<String, Any>,
     val walletConfig: WalletConfig,
-    private val setResponseUri: (String) -> Unit,
+    private val setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit,
     val walletNonce: String,
 ) {
     private var shouldValidateWithWalletMetadata = false
     private var specVersionHandler: SpecVersionHandler = SpecVersionHandler.from(specVersion)
+    private var responseDispatchInfo: ResponseDispatchInfo? = null
 
     open fun validateClientId() {
         return
@@ -86,9 +89,46 @@ abstract class ClientIdPrefixBasedAuthorizationRequestHandler(
         validateClientId()
         fetchAuthorizationRequest()
         validateClientAuthenticity()
-        setResponseUrl()
+        prepareDispatchInfo()
+        responseDispatchInfo?.let { setResponseDispatchInfo(it) }
         validateAndParseRequestFields()
+        responseDispatchInfo?.let { setResponseDispatchInfo(it) }
         return createAuthorizationRequest()
+    }
+
+    fun prepareDispatchInfo() {
+        // missing nonce is not notified to the verifier
+        val nonce = getStringValue(authorizationRequestParameters, NONCE.value)
+        validate(NONCE.value, nonce, className, notifyVerifier = false)
+
+        val state = getStringValue(authorizationRequestParameters, STATE.value)
+        state?.let { validate(STATE.value, state, className) }
+
+        val responseMode = getStringValue(authorizationRequestParameters, RESPONSE_MODE.value)
+            ?: throw OpenID4VPExceptions.MissingInput(listOf(RESPONSE_MODE.value), "", className)
+
+        val responseUrl = ResponseModeBasedHandlerFactory.get(responseMode)
+            .getResponseEndpoint(authorizationRequestParameters)
+
+        // redirect_uri must not be present for direct_post / direct_post.jwt
+        if (responseMode == DIRECT_POST.value || responseMode == DIRECT_POST_JWT.value) {
+            if (authorizationRequestParameters.containsKey(REDIRECT_URI.value)) {
+                throw OpenID4VPExceptions.InvalidData(
+                    "${REDIRECT_URI.value} should not be present for given response_mode",
+                    className
+                )
+            }
+        }
+
+        responseDispatchInfo = ResponseDispatchInfo(
+            responseMode = responseMode,
+            nonce = nonce,
+            walletNonce = walletNonce,
+            state = state,
+            clientId = clientId,
+            responseUrl = responseUrl,
+            responseEncryptionSpecification = null
+        )
     }
 
     internal fun setSpecVersionHandler(specVersion: SpecVersion) {
@@ -377,23 +417,7 @@ abstract class ClientIdPrefixBasedAuthorizationRequestHandler(
 
     abstract fun getWalletMetadata(walletConfig: WalletConfig): Map<String, Any>
 
-    fun setResponseUrl() {
-        val responseMode = getStringValue(authorizationRequestParameters, RESPONSE_MODE.value)
-            ?: throw OpenID4VPExceptions.MissingInput(listOf(RESPONSE_MODE.value), "", className)
-        // redirect_uri must not be present for direct_post / direct_post.jwt
-        if (responseMode == DIRECT_POST.value || responseMode == DIRECT_POST_JWT.value) {
-            if (authorizationRequestParameters.containsKey(REDIRECT_URI.value)) {
-                throw OpenID4VPExceptions.InvalidData(
-                    "${REDIRECT_URI.value} should not be present for given response_mode",
-                    className
-                )
-            }
-        }
-        ResponseModeBasedHandlerFactory.get(responseMode)
-            .setResponseUrl(authorizationRequestParameters, setResponseUri)
-    }
-
-    fun validateAndParseRequestFields() {
+    open fun validateAndParseRequestFields() {
         if (authorizationRequestParameters.containsKey(TRANSACTION_DATA.value)) {
             throw OpenID4VPExceptions.InvalidTransactionData(
                 "Invalid Request: transaction_data is not supported in the authorization request",
@@ -403,18 +427,21 @@ abstract class ClientIdPrefixBasedAuthorizationRequestHandler(
         val responseType = getStringValue(authorizationRequestParameters, RESPONSE_TYPE.value)
         validate(RESPONSE_TYPE.value, responseType, className)
         validateResponseTypeSupported(responseType!!)
-        // missing nonce is not notified to the verifier
-        val nonce = getStringValue(authorizationRequestParameters, NONCE.value)
-        validate(NONCE.value, nonce, className, notifyVerifier = false)
-        val state = getStringValue(authorizationRequestParameters, STATE.value)
-        state?.let {
-            validate(STATE.value, state, className)
-        }
 
         specVersionHandler.parseAndValidateClientMetadata(
             authorizationRequestParameters,
             shouldValidateWithWalletMetadata,
             walletConfig
+        )
+
+        val responseEncryptionSpecification =
+            specVersionHandler.validateClientMetadataAsPerResponseModeAndGetResponseEncryptionSpecification(
+                authorizationRequestParameters,
+                shouldValidateWithWalletMetadata,
+                walletConfig
+            )
+        responseDispatchInfo = responseDispatchInfo?.copy(
+            responseEncryptionSpecification = responseEncryptionSpecification
         )
 
         specVersionHandler.validatePresentationRequest(
@@ -459,6 +486,22 @@ abstract class ClientIdPrefixBasedAuthorizationRequestHandler(
                 is SpecV1 -> ClientMetadataSpecVersionHandler.V1
             }
             handler.parseAndValidate(
+                authorizationRequestParameters,
+                shouldValidateWithWalletMetadata,
+                walletConfig
+            )
+        }
+
+        fun validateClientMetadataAsPerResponseModeAndGetResponseEncryptionSpecification(
+            authorizationRequestParameters: MutableMap<String, Any>,
+            shouldValidateWithWalletMetadata: Boolean,
+            walletConfig: WalletConfig
+        ): ResponseEncryptionSpecification? {
+            val handler = when (this) {
+                is Draft23 -> ClientMetadataSpecVersionHandler.DRAFT_23
+                is SpecV1 -> ClientMetadataSpecVersionHandler.V1
+            }
+            return handler.validateAsPerResponseModeAndGetResponseEncryptionSpecification(
                 authorizationRequestParameters,
                 shouldValidateWithWalletMetadata,
                 walletConfig

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/DecentralizedIdentifierPrefixAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/DecentralizedIdentifierPrefixAuthorizationRequestHandler.kt
@@ -10,6 +10,7 @@ import io.mosip.openID4VP.constants.ClientIdScheme
 import io.mosip.openID4VP.constants.SignatureAlgorithm
 import io.mosip.openID4VP.constants.SpecVersion
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
 import io.mosip.vercred.vcverifier.keyResolver.types.did.DidPublicKeyResolver
 import java.security.PublicKey
 
@@ -20,14 +21,14 @@ class DecentralizedIdentifierPrefixAuthorizationRequestHandler(
     specVersion: SpecVersion,
     authorizationRequestParameters: MutableMap<String, Any>,
     walletConfig: WalletConfig,
-    setResponseUri: (String) -> Unit,
+    setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit,
     walletNonce: String,
 ) : ClientIdPrefixBasedAuthorizationRequestHandler(
     clientId,
     specVersion,
     authorizationRequestParameters,
     walletConfig,
-    setResponseUri,
+    setResponseDispatchInfo,
     walletNonce
 ) {
     override fun isSignedRequestSupported(): Boolean {

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandler.kt
@@ -12,6 +12,7 @@ import io.mosip.openID4VP.common.decodeFromBase64Url
 import io.mosip.openID4VP.common.getStringValue
 import io.mosip.openID4VP.common.resolveJwksFromUri
 import io.mosip.openID4VP.constants.ClientIdPrefix
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
 import io.mosip.openID4VP.constants.SignatureAlgorithm
 import io.mosip.openID4VP.constants.SpecVersion
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
@@ -32,14 +33,14 @@ class PreRegisteredSchemeAuthorizationRequestHandler(
     specVersion: SpecVersion,
     authorizationRequestParameters: MutableMap<String, Any>,
     walletConfig: WalletConfig,
-    setResponseUri: (String) -> Unit,
+    setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit,
     walletNonce: String,
 ) : ClientIdPrefixBasedAuthorizationRequestHandler(
     clientId,
     specVersion,
     authorizationRequestParameters,
     walletConfig,
-    setResponseUri,
+    setResponseDispatchInfo,
     walletNonce
 ) {
 

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.kt
@@ -18,6 +18,7 @@ import io.mosip.openID4VP.constants.ResponseMode.IAE_POST
 import io.mosip.openID4VP.constants.ResponseMode.IAE_POST_JWT
 import io.mosip.openID4VP.constants.SpecVersion
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
 import java.security.PublicKey
 import java.util.logging.Logger
 
@@ -28,14 +29,14 @@ class RedirectUriPrefixAuthorizationRequestHandler(
     specVersion: SpecVersion,
     authorizationRequestParameters: MutableMap<String, Any>,
     walletConfig: WalletConfig,
-    setResponseUri: (String) -> Unit,
+    setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit,
     walletNonce: String
 ) : ClientIdPrefixBasedAuthorizationRequestHandler(
     clientId,
     specVersion,
     authorizationRequestParameters,
     walletConfig,
-    setResponseUri,
+    setResponseDispatchInfo,
     walletNonce
 ) {
 

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/clientMetadata/ClientMetadataUtil.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationRequest/clientMetadata/ClientMetadataUtil.kt
@@ -7,6 +7,7 @@ import io.mosip.openID4VP.authorizationRequest.deserializeAndValidate
 import io.mosip.openID4VP.common.getStringValue
 import io.mosip.openID4VP.constants.SpecVersion
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
+import io.mosip.openID4VP.responseModeHandler.ResponseEncryptionSpecification
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandlerFactory
 
 private val className = ClientMetadata::class.simpleName!!
@@ -61,7 +62,13 @@ enum class ClientMetadataSpecVersionHandler {
                 }
             }
         }
+    }
 
+    fun validateAsPerResponseModeAndGetResponseEncryptionSpecification(
+        authorizationRequestParameters: Map<String, Any>,
+        shouldValidateWithWalletMetadata: Boolean,
+        walletConfig: WalletConfig
+    ): ResponseEncryptionSpecification? {
         val responseMode = getStringValue(
             authorizationRequestParameters,
             RESPONSE_MODE.value
@@ -70,7 +77,7 @@ enum class ClientMetadataSpecVersionHandler {
         )
 
         val parsedClientMetadata = authorizationRequestParameters[CLIENT_METADATA.value]
-        when (this) {
+        return when (this) {
             DRAFT_23 -> ResponseModeBasedHandlerFactory.get(responseMode)
                 .validate(
                     parsedClientMetadata as? ClientMetadataDraft23,

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationErrorResponse.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationErrorResponse.kt
@@ -12,6 +12,6 @@ fun AuthorizationErrorResponse.toJsonEncodedMap(): Map<String, String> {
     return buildMap {
         put("error", error)
         put("error_description", errorDescription)
-        state?.let { put("state", it) }
+        state?.takeIf { it.isNotBlank() }?.let { put("state", it) }
     }
 }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandler.kt
@@ -16,17 +16,13 @@ import io.mosip.openID4VP.authorizationResponse.vpToken.VPTokenType
 import io.mosip.openID4VP.authorizationResponse.vpToken.VPTokenType.VPTokenArray
 import io.mosip.openID4VP.authorizationResponse.vpToken.VPTokenType.VPTokenElement
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
-import io.mosip.openID4VP.common.OpenID4VPErrorFields
 import io.mosip.openID4VP.common.UUIDGenerator
-import io.mosip.openID4VP.constants.ContentType
 import io.mosip.openID4VP.constants.FormatType
-import io.mosip.openID4VP.constants.HttpMethod
-import io.mosip.openID4VP.constants.ResponseMode
 import io.mosip.openID4VP.constants.ResponseType
 import io.mosip.openID4VP.constants.SpecVersion
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
-import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
 import io.mosip.openID4VP.networkManager.NetworkResponse
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandlerFactory
 import io.mosip.openID4VP.verifier.VerifierResponse
 import io.mosip.openID4VP.wallet.Credential
@@ -85,59 +81,51 @@ internal class AuthorizationResponseHandler(
         }
     }
 
+    private fun resolveError(exception: Exception): OpenID4VPExceptions =
+        exception as? OpenID4VPExceptions ?: OpenID4VPExceptions.GenericFailure(
+            message = exception.message ?: "Unknown internal error",
+            className = OpenID4VP::class.simpleName.orEmpty()
+        )
+
     internal fun constructAuthorizationErrorResponse(
-        authorizationRequest: AuthorizationRequest?,
+        dispatchInfo: ResponseDispatchInfo?,
         exception: Exception,
-        walletNonce: String
+        walletNonce: String,
+        authorizationRequest: AuthorizationRequest? = null
     ): Map<String, Any> {
         this.walletNonce = walletNonce
-        val authorizationResponse = when (exception) {
-            is OpenID4VPExceptions -> exception.toAuthorizationErrorResponse(authorizationRequest?.state)
-            else -> OpenID4VPExceptions.GenericFailure(
-                message = exception.message ?: "Unknown internal error",
-                className = OpenID4VP::class.simpleName.orEmpty()
-            ).toAuthorizationErrorResponse(state = authorizationRequest?.state)
+        val resolvedError = resolveError(exception)
+        return try {
+            val dispatch = dispatchInfo ?: throw OpenID4VPExceptions.ErrorDispatchFailure(
+                message = "Response dispatch details are not set. Cannot send error to verifier.",
+                className = className
+            )
+            val authorizationErrorResponse = resolvedError.toAuthorizationErrorResponse(dispatch.state)
+            ResponseModeBasedHandlerFactory.get(dispatch.responseMode)
+                .getAuthorizationErrorResponse(dispatch, authorizationErrorResponse, authorizationRequest)
+        } catch (error: Exception) {
+            OpenID4VPExceptions.error(error.message ?: error.toString(), className)
+            mapOf(
+                "error" to "invalid_request",
+                "error_description" to (error.message ?: "Unknown internal error")
+            )
         }
-
-        return ResponseModeBasedHandlerFactory.get(
-            authorizationRequest?.responseMode ?: ResponseMode.DIRECT_POST.value
-        ).getAuthorizationErrorResponse(
-            authorizationRequest,
-            authorizationResponse,
-            this.walletNonce
-        )
     }
 
     internal fun sendAuthorizationError(
-        responseUri: String?,
+        dispatchInfo: ResponseDispatchInfo?,
         authorizationRequest: AuthorizationRequest?,
         exception: Exception
     ): VerifierResponse {
-        if (responseUri == null) {
-            throw OpenID4VPExceptions.ErrorDispatchFailure(
-                message = "Response URI is not set. Cannot send error to verifier.",
-                className = className
-            )
-        }
+        val dispatch = dispatchInfo ?: throw OpenID4VPExceptions.ErrorDispatchFailure(
+            message = "Response dispatch details are not set. Cannot send error to verifier.",
+            className = className
+        )
+        val resolvedError = resolveError(exception)
         try {
-            val errorPayload = when (exception) {
-                is OpenID4VPExceptions -> exception.toErrorResponse()
-                else -> OpenID4VPExceptions.GenericFailure(
-                    message = exception.message ?: "Unknown internal error",
-                    className = OpenID4VP::class.simpleName.orEmpty()
-                ).toErrorResponse()
-            }.apply {
-                authorizationRequest?.state?.takeIf { it.isNotBlank() }?.let {
-                    this[OpenID4VPErrorFields.STATE] = it
-                }
-            }
-
-            val networkResponse = sendHTTPRequest(
-                url = responseUri,
-                method = HttpMethod.POST,
-                bodyParams = errorPayload,
-                headers = mapOf("Content-Type" to ContentType.APPLICATION_FORM_URL_ENCODED.value)
-            )
+            val authorizationErrorResponse = resolvedError.toAuthorizationErrorResponse(dispatch.state)
+            val networkResponse = ResponseModeBasedHandlerFactory.get(dispatch.responseMode)
+                .sendAuthorizationError(dispatch, authorizationErrorResponse, authorizationRequest)
             val verifierResponse = toVerifierResponse(networkResponse)
             (exception as? OpenID4VPExceptions)?.setVerifierResponse(verifierResponse)
             return verifierResponse
@@ -152,13 +140,19 @@ internal class AuthorizationResponseHandler(
     internal fun constructVPResponse(
         vpTokenSigningResults: List<VPTokenSigningResult>,
         authorizationRequest: AuthorizationRequest,
+        dispatchInfo: ResponseDispatchInfo?
     ): Map<String, String> {
         try {
-            val reconstructedResults = reconstructSigningResults(vpTokenSigningResults)
-            return constructAuthorizationResponse(
+            val authorizationResponse = createAuthorizationResponse(
                 authorizationRequest = authorizationRequest,
-                vpTokenSigningResults = reconstructedResults
+                vpTokenSigningResults = reconstructSigningResults(vpTokenSigningResults)
             )
+            val dispatch = dispatchInfo ?: throw OpenID4VPExceptions.ErrorDispatchFailure(
+                message = "Response dispatch details are not set. Cannot construct VP response.",
+                className = className
+            )
+            return ResponseModeBasedHandlerFactory.get(dispatch.responseMode)
+                .getAuthorizationResponse(dispatch, authorizationResponse, authorizationRequest)
         } catch (exception: Exception) {
             throw OpenID4VPExceptions.AuthorizationResponseConstructionFailure(exception, className)
         }
@@ -167,8 +161,12 @@ internal class AuthorizationResponseHandler(
     internal fun constructAndSendAuthorizationResponseToVerifier(
         authorizationRequest: AuthorizationRequest,
         vpTokenSigningResults: List<VPTokenSigningResult>,
-        responseUri: String,
+        dispatchInfo: ResponseDispatchInfo?
     ): VerifierResponse {
+        val dispatch = dispatchInfo ?: throw OpenID4VPExceptions.ErrorDispatchFailure(
+            message = "Response dispatch details are not set. Cannot send authorization response to verifier.",
+            className = className
+        )
         val authorizationResponse: AuthorizationResponse = try {
             createAuthorizationResponse(
                 authorizationRequest = authorizationRequest,
@@ -177,30 +175,9 @@ internal class AuthorizationResponseHandler(
         } catch (exception: Exception) {
             throw OpenID4VPExceptions.AuthorizationResponseConstructionFailure(exception, className)
         }
-        val networkResponse = sendAuthorizationResponse(
-            authorizationResponse = authorizationResponse,
-            responseUri = responseUri,
-            authorizationRequest = authorizationRequest
-        )
+        val networkResponse = ResponseModeBasedHandlerFactory.get(dispatch.responseMode)
+            .sendAuthorizationResponse(dispatch, authorizationResponse, authorizationRequest)
         return toVerifierResponse(networkResponse)
-    }
-
-    private fun constructAuthorizationResponse(
-        authorizationRequest: AuthorizationRequest,
-        vpTokenSigningResults: Map<FormatType, List<VPTokenSigningResult>>,
-    ): Map<String, String> {
-        val authorizationResponse: AuthorizationResponse = createAuthorizationResponse(
-            authorizationRequest = authorizationRequest,
-            vpTokenSigningResults = vpTokenSigningResults
-        )
-
-        return ResponseModeBasedHandlerFactory.get(authorizationRequest.responseMode!!)
-            .getAuthorizationResponse(
-                authorizationRequest,
-                authorizationResponse,
-                walletNonce,
-                walletConfig
-            )
     }
 
 
@@ -232,21 +209,6 @@ internal class AuthorizationResponseHandler(
             signingResults = vpTokenSigningResults,
             className = className
         )
-    }
-
-    private fun sendAuthorizationResponse(
-        authorizationResponse: AuthorizationResponse,
-        responseUri: String,
-        authorizationRequest: AuthorizationRequest,
-    ): NetworkResponse {
-        return ResponseModeBasedHandlerFactory.get(authorizationRequest.responseMode!!)
-            .sendAuthorizationResponse(
-                authorizationRequest = authorizationRequest,
-                url = responseUri,
-                authorizationResponse = authorizationResponse,
-                walletNonce = walletNonce,
-                walletConfig = walletConfig
-            )
     }
 
     internal fun createVPTokenAndPresentationSubmission(

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/ResponseDispatchInfo.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/ResponseDispatchInfo.kt
@@ -1,0 +1,21 @@
+package io.mosip.openID4VP.responseModeHandler
+
+import io.mosip.openID4VP.authorizationRequest.clientMetadata.Jwk
+import io.mosip.openID4VP.constants.EncryptionAlgorithm
+import io.mosip.openID4VP.constants.EncryptionMethod
+
+data class ResponseDispatchInfo(
+    val responseMode: String,
+    val nonce: String?,
+    val walletNonce: String?,
+    val state: String?,
+    val clientId: String,
+    val responseUrl: String,
+    val responseEncryptionSpecification: ResponseEncryptionSpecification? = null
+)
+
+data class ResponseEncryptionSpecification(
+    val keyEncryptionAlg: EncryptionAlgorithm,
+    val contentEncryptionAlg: EncryptionMethod,
+    val verifierPublicKey: Jwk
+)

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/ResponseModeBasedHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/ResponseModeBasedHandler.kt
@@ -22,53 +22,49 @@ abstract class ResponseModeBasedHandler {
         clientMetadata: ClientMetadata?,
         walletConfig: WalletConfig,
         shouldValidateWithWalletMetadata: Boolean
-    ){
-        return
-    }
+    ): ResponseEncryptionSpecification? = null
 
     open fun validate(
         clientMetadata: ClientMetadataDraft23?,
         walletConfig: WalletConfig,
         shouldValidateWithWalletMetadata: Boolean
-    ){
-        return
-    }
+    ): ResponseEncryptionSpecification? = null
 
-    abstract fun sendAuthorizationResponse(
-        authorizationRequest: AuthorizationRequest,
-        url: String,
-        authorizationResponse: AuthorizationResponse,
-        walletNonce: String,
-        walletConfig: WalletConfig
-    ): NetworkResponse
-
-    fun setResponseUrl(
-        authorizationRequestParameters: Map<String, Any>,
-        setResponseUri: (String) -> Unit
-    ) {
+    fun getResponseEndpoint(authorizationRequestParameters: Map<String, Any>): String {
         val responseUri = getStringValue(authorizationRequestParameters, RESPONSE_URI.value)
         validate(RESPONSE_URI.value, responseUri, className)
         if (!isValidUrl(responseUri!!)) {
             throw OpenID4VPExceptions.InvalidData("${RESPONSE_URI.value} data is not valid", className)
         }
-        setResponseUri(responseUri)
+        return responseUri
     }
-
-    abstract fun getAuthorizationResponse(
-        authorizationRequest: AuthorizationRequest,
-        authorizationResponse: AuthorizationResponse,
-        walletNonce: String,
-        walletConfig: WalletConfig
-    ): Map<String, String>
-
-    abstract fun getAuthorizationErrorResponse(
-        authorizationRequest: AuthorizationRequest?,
-        authorizationResponse: AuthorizationErrorResponse,
-        walletNonce: String
-    ): Map<String, String>
 
     open fun getVerifierPublicKeyForEncryption(
         authorizationRequest: AuthorizationRequest,
         walletConfig: WalletConfig
     ): Jwk? = null
+
+    abstract fun getAuthorizationResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest
+    ): Map<String, String>
+
+    abstract fun sendAuthorizationResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest
+    ): NetworkResponse
+
+    abstract fun getAuthorizationErrorResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?
+    ): Map<String, String>
+
+    abstract fun sendAuthorizationError(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?
+    ): NetworkResponse
 }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostJwtResponseModeHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostJwtResponseModeHandler.kt
@@ -11,6 +11,7 @@ import io.mosip.openID4VP.authorizationResponse.AuthorizationErrorResponse
 import io.mosip.openID4VP.authorizationResponse.AuthorizationResponse
 import io.mosip.openID4VP.authorizationResponse.toJsonEncodedMap
 import io.mosip.openID4VP.authorizationResponse.toMap
+import io.mosip.openID4VP.common.generateNonce
 import io.mosip.openID4VP.constants.EncryptionMethod
 import io.mosip.openID4VP.jwt.jwe.JWEHandler
 import io.mosip.openID4VP.constants.ContentType
@@ -19,6 +20,8 @@ import io.mosip.openID4VP.constants.EncryptionAlgorithm
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
 import io.mosip.openID4VP.networkManager.NetworkResponse
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
+import io.mosip.openID4VP.responseModeHandler.ResponseEncryptionSpecification
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandler
 
 private val className = DirectPostJwtResponseModeHandler::class.simpleName!!
@@ -29,7 +32,7 @@ class DirectPostJwtResponseModeHandler : ResponseModeBasedHandler() {
         clientMetadata: ClientMetadataDraft23?,
         walletConfig: WalletConfig,
         shouldValidateWithWalletMetadata: Boolean
-    ) {
+    ): ResponseEncryptionSpecification {
         requireNotNull(clientMetadata) {
             throwInvalidDataException("client_metadata must be present for given response mode")
         }
@@ -50,14 +53,15 @@ class DirectPostJwtResponseModeHandler : ResponseModeBasedHandler() {
             shouldValidate = shouldValidateWithWalletMetadata
         )
 
-        selectEncryptionKey(jwks.keys, listOf(alg))
+        val encryptionKey = selectEncryptionKey(jwks.keys, listOf(alg))
+        return buildEncryptionSpecification(alg, enc, encryptionKey)
     }
 
     override fun validate(
         clientMetadata: ClientMetadata?,
         walletConfig: WalletConfig,
         shouldValidateWithWalletMetadata: Boolean
-    ) {
+    ): ResponseEncryptionSpecification {
         requireNotNull(clientMetadata) {
             throwInvalidDataException("client_metadata must be present for given response mode")
         }
@@ -84,7 +88,33 @@ class DirectPostJwtResponseModeHandler : ResponseModeBasedHandler() {
             walletConfig.authorizationEncryptionAlgValuesSupported?.map { it.value } ?: listOf(
                 EncryptionAlgorithm.ECDH_ES.value
             )
-        selectEncryptionKey(jwks.keys, walletSupportedEncryptionAlgorithms)
+        val encryptionKey = selectEncryptionKey(jwks.keys, walletSupportedEncryptionAlgorithms)
+
+        val walletEncValues =
+            walletConfig.authorizationEncryptionEncValuesSupported?.map { it.value }
+                ?: listOf(EncryptionMethod.A256GCM.value)
+        val contentEncryptionAlgorithm = walletEncValues.firstOrNull { encValues.contains(it) }
+            ?: throwInvalidDataException("Unsupported content encryption algorithm")
+        val verifierPublicKeyAlgorithm = encryptionKey.alg
+            ?: throwInvalidDataException("Algorithm must be specified for the encryption key in jwks")
+
+        return buildEncryptionSpecification(
+            verifierPublicKeyAlgorithm,
+            contentEncryptionAlgorithm,
+            encryptionKey
+        )
+    }
+
+    private fun buildEncryptionSpecification(
+        keyEncryptionAlg: String,
+        contentEncryptionAlg: String,
+        verifierPublicKey: Jwk
+    ): ResponseEncryptionSpecification {
+        val keyAlg = EncryptionAlgorithm.fromValue(keyEncryptionAlg)
+            ?: throwInvalidDataException("Unsupported key encryption algorithm: $keyEncryptionAlg")
+        val contentAlg = EncryptionMethod.fromValue(contentEncryptionAlg)
+            ?: throwInvalidDataException("Unsupported content encryption algorithm: $contentEncryptionAlg")
+        return ResponseEncryptionSpecification(keyAlg, contentAlg, verifierPublicKey)
     }
 
     private fun validateEncryption(
@@ -120,49 +150,6 @@ class DirectPostJwtResponseModeHandler : ResponseModeBasedHandler() {
         throw OpenID4VPExceptions.InvalidData(message, className)
     }
 
-    override fun sendAuthorizationResponse(
-        authorizationRequest: AuthorizationRequest,
-        url: String,
-        authorizationResponse: AuthorizationResponse,
-        walletNonce: String,
-        walletConfig: WalletConfig
-    ): NetworkResponse {
-        val encryptedBodyParams = getAuthorizationResponse(
-            authorizationRequest,
-            authorizationResponse,
-            walletNonce,
-            walletConfig
-        )
-
-        return sendHTTPRequest(
-            url = url,
-            method = HttpMethod.POST,
-            bodyParams = encryptedBodyParams,
-            headers = mapOf("Content-Type" to ContentType.APPLICATION_FORM_URL_ENCODED.value)
-        )
-    }
-
-    override fun getAuthorizationResponse(
-        authorizationRequest: AuthorizationRequest,
-        authorizationResponse: AuthorizationResponse,
-        walletNonce: String,
-        walletConfig: WalletConfig
-    ): Map<String, String> {
-        return encryptResponse(
-            authorizationRequest, walletNonce,
-            authorizationResponse.toMap(),
-            walletConfig
-        )
-    }
-
-    override fun getAuthorizationErrorResponse(
-        authorizationRequest: AuthorizationRequest?,
-        authorizationResponse: AuthorizationErrorResponse,
-        walletNonce: String
-    ): Map<String, String> {
-        return authorizationResponse.toJsonEncodedMap()
-    }
-
     override fun getVerifierPublicKeyForEncryption(
         authorizationRequest: AuthorizationRequest,
         walletConfig: WalletConfig
@@ -171,19 +158,74 @@ class DirectPostJwtResponseModeHandler : ResponseModeBasedHandler() {
             .getVerifierPublicKey(authorizationRequest, walletConfig, className)
     }
 
-    private fun encryptResponse(
-        authorizationRequest: AuthorizationRequest,
-        walletNonce: String,
-        responseParams: Map<String, Any>,
-        walletConfig: WalletConfig
+    override fun getAuthorizationResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest
     ): Map<String, String> {
-        val specVersionHandler = SpecVersionHandler.from(authorizationRequest)
-        val jweHandler = specVersionHandler.getJWEHandler(
-            authorizationRequest,
-            walletNonce,
-            walletConfig,
-            className
+        val jweHandler = makeJWEHandler(dispatchInfo, authorizationRequest.nonce)
+        return encryptResponse(authorizationResponse.toMap(), jweHandler)
+    }
+
+    override fun getAuthorizationErrorResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?
+    ): Map<String, String> {
+        val errorMap = authorizationResponse.toJsonEncodedMap()
+        if (dispatchInfo.responseEncryptionSpecification == null) {
+            return errorMap
+        }
+        val recipientNonce = authorizationRequest?.nonce ?: dispatchInfo.nonce ?: ""
+        val jweHandler = makeJWEHandler(dispatchInfo, recipientNonce)
+        return encryptResponse(errorMap, jweHandler)
+    }
+
+    override fun sendAuthorizationResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest
+    ): NetworkResponse {
+        return sendHTTPRequest(
+            url = dispatchInfo.responseUrl,
+            method = HttpMethod.POST,
+            bodyParams = getAuthorizationResponse(dispatchInfo, authorizationResponse, authorizationRequest),
+            headers = mapOf("Content-Type" to ContentType.APPLICATION_FORM_URL_ENCODED.value)
         )
+    }
+
+    override fun sendAuthorizationError(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?
+    ): NetworkResponse {
+        return sendHTTPRequest(
+            url = dispatchInfo.responseUrl,
+            method = HttpMethod.POST,
+            bodyParams = getAuthorizationErrorResponse(dispatchInfo, authorizationResponse, authorizationRequest),
+            headers = mapOf("Content-Type" to ContentType.APPLICATION_FORM_URL_ENCODED.value)
+        )
+    }
+
+    private fun makeJWEHandler(dispatchInfo: ResponseDispatchInfo, recipientNonce: String): JWEHandler {
+        val encryptionSpec = dispatchInfo.responseEncryptionSpecification
+            ?: throw OpenID4VPExceptions.InvalidData(
+                "responseEncryptionSpecification is required for response mode 'direct_post.jwt'",
+                className
+            )
+        return JWEHandler(
+            keyEncryptionAlg = encryptionSpec.keyEncryptionAlg.value,
+            contentEncryptionAlg = encryptionSpec.contentEncryptionAlg.value,
+            publicKey = encryptionSpec.verifierPublicKey,
+            walletNonce = dispatchInfo.walletNonce ?: generateNonce(),
+            verifierNonce = recipientNonce
+        )
+    }
+
+    private fun encryptResponse(
+        responseParams: Map<String, Any>,
+        jweHandler: JWEHandler
+    ): Map<String, String> {
         val encryptedBody = jweHandler.generateEncryptedResponse(responseParams)
         return mapOf("response" to encryptedBody)
     }
@@ -227,71 +269,9 @@ class DirectPostJwtResponseModeHandler : ResponseModeBasedHandler() {
                             className
                         )
                     val supportedAlgs =
-                        walletConfig?.authorizationEncryptionAlgValuesSupported?.map { it.value }
+                        walletConfig.authorizationEncryptionAlgValuesSupported?.map { it.value }
                             ?: listOf(EncryptionAlgorithm.ECDH_ES.value)
                     selectEncryptionKey(verifierJwks.keys, supportedAlgs)
-                }
-            }
-        }
-
-        fun getJWEHandler(
-            authorizationRequest: AuthorizationRequest,
-            walletNonce: String,
-            walletConfig: WalletConfig,
-            className: String
-        ): JWEHandler {
-            return when (this) {
-                is Draft23 -> {
-                    val clientMetadata =
-                        (authorizationRequest as AuthorizationPresentationExchangeRequest).clientMetadata!!
-                    val verifierPublicKey =
-                        getVerifierPublicKey(authorizationRequest, walletConfig, className)
-                    JWEHandler(
-                        keyEncryptionAlg = clientMetadata.authorizationEncryptedResponseAlg!!,
-                        contentEncryptionAlg = clientMetadata.authorizationEncryptedResponseEnc!!,
-                        publicKey = verifierPublicKey,
-                        walletNonce = walletNonce,
-                        verifierNonce = authorizationRequest.nonce
-                    )
-                }
-
-                is V1 -> {
-                    val clientMetadata =
-                        (authorizationRequest as? AuthorizationDcqlRequest)?.clientMetadata
-                            ?: throw OpenID4VPExceptions.InvalidData(
-                                "client_metadata must be present for given response mode",
-                                className
-                            )
-                    val encValues = clientMetadata.encryptedResponseEncValuesSupported
-                    if (encValues.isNullOrEmpty()) {
-                        throw OpenID4VPExceptions.InvalidData(
-                            "Unsupported content encryption algorithm",
-                            className
-                        )
-                    }
-                    val walletEncValues =
-                        walletConfig?.authorizationEncryptionEncValuesSupported?.map { it.value }
-                            ?: listOf(EncryptionMethod.A256GCM.value)
-                    val contentEncryptionAlgorithm =
-                        walletEncValues.firstOrNull { encValues.contains(it) }
-                            ?: throw OpenID4VPExceptions.InvalidData(
-                                "Unsupported content encryption algorithm",
-                                className
-                            )
-                    val verifierPublicKey =
-                        getVerifierPublicKey(authorizationRequest, walletConfig, className)
-                    val verifierPublicKeyAlg = verifierPublicKey.alg
-                        ?: throw OpenID4VPExceptions.InvalidData(
-                            "Algorithm must be specified for the encryption key in jwks",
-                            className
-                        )
-                    JWEHandler(
-                        keyEncryptionAlg = verifierPublicKeyAlg,
-                        contentEncryptionAlg = contentEncryptionAlgorithm,
-                        publicKey = verifierPublicKey,
-                        walletNonce = walletNonce,
-                        verifierNonce = authorizationRequest.nonce
-                    )
                 }
             }
         }

--- a/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostResponseModeHandler.kt
+++ b/kotlin/openID4VP/src/commonMain/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostResponseModeHandler.kt
@@ -8,6 +8,8 @@ import io.mosip.openID4VP.authorizationResponse.AuthorizationErrorResponse
 import io.mosip.openID4VP.authorizationResponse.AuthorizationResponse
 import io.mosip.openID4VP.authorizationResponse.toJsonEncodedMap
 import io.mosip.openID4VP.networkManager.NetworkManagerClient.Companion.sendHTTPRequest
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
+import io.mosip.openID4VP.responseModeHandler.ResponseEncryptionSpecification
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandler
 import io.mosip.openID4VP.constants.ContentType.APPLICATION_FORM_URL_ENCODED
 import io.mosip.openID4VP.constants.HttpMethod
@@ -18,48 +20,53 @@ class DirectPostResponseModeHandler : ResponseModeBasedHandler() {
         clientMetadata: ClientMetadata?,
         walletConfig: WalletConfig,
         shouldValidateWithWalletMetadata: Boolean
-    ) {
-        return
-    }
+    ): ResponseEncryptionSpecification? = null
 
     override fun validate(
         clientMetadata: ClientMetadataDraft23?,
         walletConfig: WalletConfig,
         shouldValidateWithWalletMetadata: Boolean
-    ) {
-        return
-    }
+    ): ResponseEncryptionSpecification? = null
 
     override fun getAuthorizationResponse(
-        authorizationRequest: AuthorizationRequest,
+        dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationResponse,
-        walletNonce: String,
-        walletConfig: WalletConfig
+        authorizationRequest: AuthorizationRequest
     ): Map<String, String> {
         return authorizationResponse.toJsonEncodedMap()
     }
 
     override fun getAuthorizationErrorResponse(
-        authorizationRequest: AuthorizationRequest?,
+        dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationErrorResponse,
-        walletNonce: String
+        authorizationRequest: AuthorizationRequest?
     ): Map<String, String> {
         return authorizationResponse.toJsonEncodedMap()
     }
 
     override fun sendAuthorizationResponse(
-        authorizationRequest: AuthorizationRequest,
-        url: String,
+        dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationResponse,
-        walletNonce: String,
-        walletConfig: WalletConfig
+        authorizationRequest: AuthorizationRequest
     ): NetworkResponse {
-        val response = sendHTTPRequest(
-            url = url,
+        return sendHTTPRequest(
+            url = dispatchInfo.responseUrl,
             method = HttpMethod.POST,
-            bodyParams = getAuthorizationResponse(authorizationRequest, authorizationResponse, walletNonce, walletConfig),
+            bodyParams = getAuthorizationResponse(dispatchInfo, authorizationResponse, authorizationRequest),
             headers = mapOf("Content-Type" to APPLICATION_FORM_URL_ENCODED.value)
         )
-        return response
+    }
+
+    override fun sendAuthorizationError(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?
+    ): NetworkResponse {
+        return sendHTTPRequest(
+            url = dispatchInfo.responseUrl,
+            method = HttpMethod.POST,
+            bodyParams = getAuthorizationErrorResponse(dispatchInfo, authorizationResponse, authorizationRequest),
+            headers = mapOf("Content-Type" to APPLICATION_FORM_URL_ENCODED.value)
+        )
     }
 }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/OpenID4VPErrorDispatchTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/OpenID4VPErrorDispatchTest.kt
@@ -45,7 +45,7 @@ class OpenID4VPErrorDispatchTest {
     @Test
     fun `authenticateVerifier sends error to verifier on failure when responseUri is set`() {
         val instance = OpenID4VP("test")
-        setField(instance, "responseUri", "https://mock-verifier.com/response-uri")
+        setField(instance, "responseDispatchInfo", testDispatchInfo("https://mock-verifier.com/response-uri"))
 
         mockkConstructor(AuthorizationResponseHandler::class)
         every {
@@ -69,7 +69,7 @@ class OpenID4VPErrorDispatchTest {
     @Test
     fun `authenticateVerifier does not notify verifier when nonce is missing`() {
         val instance = OpenID4VP("test")
-        setField(instance, "responseUri", "https://mock-verifier.com/response-uri")
+        setField(instance, "responseDispatchInfo", testDispatchInfo("https://mock-verifier.com/response-uri"))
 
         every {
             NetworkManagerClient.sendHTTPRequest(any(), any(), any(), any())
@@ -112,7 +112,7 @@ class OpenID4VPErrorDispatchTest {
     @Test
     fun `InvalidVerifier produces invalid_client error code`() {
         openID4VP.authorizationRequest = authorizationPresentationExchangeRequest
-        setField(openID4VP, "responseUri", responseUrl)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl))
 
         every { NetworkManagerClient.sendHTTPRequest(any(), any(), any(), any()) } returns NetworkResponse(200, "{}", mapOf())
 
@@ -124,7 +124,7 @@ class OpenID4VPErrorDispatchTest {
     @Test
     fun `AccessDenied produces access_denied error code`() {
         openID4VP.authorizationRequest = authorizationPresentationExchangeRequest
-        setField(openID4VP, "responseUri", responseUrl)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl))
 
         every { NetworkManagerClient.sendHTTPRequest(any(), any(), any(), any()) } returns NetworkResponse(200, "{}", mapOf())
 
@@ -136,7 +136,7 @@ class OpenID4VPErrorDispatchTest {
     @Test
     fun `InvalidData produces invalid_request error code`() {
         openID4VP.authorizationRequest = authorizationPresentationExchangeRequest
-        setField(openID4VP, "responseUri", responseUrl)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl))
 
         every { NetworkManagerClient.sendHTTPRequest(any(), any(), any(), any()) } returns NetworkResponse(200, "{}", mapOf())
 
@@ -148,7 +148,7 @@ class OpenID4VPErrorDispatchTest {
     @Test
     fun `InvalidTransactionData produces invalid_transaction_data error code`() {
         openID4VP.authorizationRequest = authorizationPresentationExchangeRequest
-        setField(openID4VP, "responseUri", responseUrl)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl))
 
         every { NetworkManagerClient.sendHTTPRequest(any(), any(), any(), any()) } returns NetworkResponse(200, "{}", mapOf())
 
@@ -160,7 +160,7 @@ class OpenID4VPErrorDispatchTest {
     @Test
     fun `generic Exception is wrapped with server_error code`() {
         openID4VP.authorizationRequest = authorizationPresentationExchangeRequest
-        setField(openID4VP, "responseUri", responseUrl)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl))
 
         every { NetworkManagerClient.sendHTTPRequest(any(), any(), any(), any()) } returns NetworkResponse(200, "{}", mapOf())
 
@@ -172,7 +172,7 @@ class OpenID4VPErrorDispatchTest {
     @Test
     fun `VP construction failure sends server_error with generic description to verifier`() {
         openID4VP.authorizationRequest = authorizationPresentationExchangeRequest
-        setField(openID4VP, "responseUri", responseUrl)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl))
 
         val mockHandler = mockk<AuthorizationResponseHandler>()
         setField(openID4VP, "authorizationResponseHandler", mockHandler)
@@ -203,7 +203,7 @@ class OpenID4VPErrorDispatchTest {
     @Test
     fun `sendErrorInfoToVerifier includes state when authorizationRequest has state`() {
         openID4VP.authorizationRequest = authorizationPresentationExchangeRequest
-        setField(openID4VP, "responseUri", responseUrl)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl))
 
         every { NetworkManagerClient.sendHTTPRequest(any(), any(), any(), any()) } returns NetworkResponse(200, "{}", mapOf())
 
@@ -217,7 +217,7 @@ class OpenID4VPErrorDispatchTest {
     @Test
     fun `sendErrorInfoToVerifier omits state when authorizationRequest state is null`() {
         openID4VP.authorizationRequest = createAuthorizationRequestWithState(null)
-        setField(openID4VP, "responseUri", responseUrl)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl, state = null))
 
         every { NetworkManagerClient.sendHTTPRequest(any(), any(), any(), any()) } returns NetworkResponse(200, "{}", mapOf())
 
@@ -229,7 +229,7 @@ class OpenID4VPErrorDispatchTest {
     @Test
     fun `sendErrorInfoToVerifier omits state when authorizationRequest state is empty`() {
         openID4VP.authorizationRequest = createAuthorizationRequestWithState("")
-        setField(openID4VP, "responseUri", responseUrl)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl, state = ""))
 
         every { NetworkManagerClient.sendHTTPRequest(any(), any(), any(), any()) } returns NetworkResponse(200, "{}", mapOf())
 
@@ -242,18 +242,18 @@ class OpenID4VPErrorDispatchTest {
 
     @Test
     fun `sendErrorInfoToVerifier throws ErrorDispatchFailure when responseUri is null`() {
-        setField(openID4VP, "responseUri", null)
+        setField(openID4VP, "responseDispatchInfo", null)
 
         val exception = assertFailsWith<OpenID4VPExceptions.ErrorDispatchFailure> {
             openID4VP.sendErrorInfoToVerifier(Exception("some error"))
         }
-        assertTrue(exception.message!!.contains("Response URI is not set"))
+        assertTrue(exception.message!!.contains("Response dispatch details are not set"))
     }
 
     @Test
     fun `sendErrorInfoToVerifier throws ErrorDispatchFailure on network error`() {
         openID4VP.authorizationRequest = authorizationPresentationExchangeRequest
-        setField(openID4VP, "responseUri", responseUrl)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl))
 
         every { NetworkManagerClient.sendHTTPRequest(any(), any(), any(), any()) } throws Exception("Network error")
 
@@ -268,7 +268,7 @@ class OpenID4VPErrorDispatchTest {
     @Test
     fun `sendErrorInfoToVerifier uses application_x-www-form-urlencoded content type`() {
         openID4VP.authorizationRequest = authorizationPresentationExchangeRequest
-        setField(openID4VP, "responseUri", responseUrl)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl))
 
         every { NetworkManagerClient.sendHTTPRequest(any(), any(), any(), any()) } returns NetworkResponse(200, "{}", mapOf())
 
@@ -287,7 +287,7 @@ class OpenID4VPErrorDispatchTest {
     @Test
     fun `sendErrorInfoToVerifier returns VerifierResponse on successful dispatch`() {
         openID4VP.authorizationRequest = authorizationPresentationExchangeRequest
-        setField(openID4VP, "responseUri", responseUrl)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl))
 
         every { NetworkManagerClient.sendHTTPRequest(any(), any(), any(), any()) } returns
                 NetworkResponse(200, """{"message":"received"}""", mapOf("Content-Type" to listOf("application/json")))

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/OpenID4VPSpecComplianceTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/OpenID4VPSpecComplianceTest.kt
@@ -162,7 +162,7 @@ class OpenID4VPWalletNonceAndStateResetTest {
 
     @Test
     fun `authenticateVerifier resets responseUri before validation`() {
-        setField(openID4VP, "responseUri", "https://old-uri.com")
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo("https://old-uri.com"))
 
         every {
             AuthorizationRequest.validateAndCreateAuthorizationRequest(
@@ -172,8 +172,8 @@ class OpenID4VPWalletNonceAndStateResetTest {
 
         openID4VP.authenticateVerifier("openid4vp://authorize?request=test")
 
-        val currentResponseUri = getFieldValue(openID4VP, "responseUri")
-        assertNotEquals("https://old-uri.com", currentResponseUri)
+        val currentDispatchInfo = getFieldValue(openID4VP, "responseDispatchInfo")
+        assertNotEquals(testDispatchInfo("https://old-uri.com"), currentDispatchInfo)
     }
 
     // --- response_type = vp_token ---

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/OpenID4VPTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/OpenID4VPTest.kt
@@ -60,7 +60,7 @@ class OpenID4VPTest {
         mockkObject(AuthorizationRequest)
         openID4VP = OpenID4VP("test-OpenID4VP")
         openID4VP.authorizationRequest = authorizationPresentationExchangeRequest
-        setField(openID4VP, "responseUri", responseUrl)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl))
         setField(openID4VP, "walletNonce", "bMHvX1HGhbh8zqlSWf/fuQ==")
     }
 
@@ -167,7 +167,7 @@ class OpenID4VPTest {
     fun `exception thrown should have verifier response if sent to verifier`() {
         val openID4VPInstance = OpenID4VP("OVPTest")
         mockkConstructor(AuthorizationResponseHandler::class)
-        setField(openID4VPInstance, "responseUri", "https://mock-verifier.com/response-uri")
+        setField(openID4VPInstance, "responseDispatchInfo", testDispatchInfo("https://mock-verifier.com/response-uri"))
         every {
             anyConstructed<AuthorizationResponseHandler>().sendAuthorizationError(
                 any(),
@@ -255,7 +255,7 @@ class OpenID4VPTest {
                 any()
             )
         } returns NetworkResponse(200, """{"message":"VP share success"}""", mapOf("Content-Type" to listOf("application/json")))
-        setField(openID4VP, "responseUri", "https://mock-verifier.com/response-uri")
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo("https://mock-verifier.com/response-uri"))
 
         val dispatchResult =
             openID4VP.sendErrorInfoToVerifier(InvalidData("Unsupported response_mode", ""))
@@ -319,7 +319,7 @@ class OpenID4VPTest {
 
     @Test
     fun `should throw exception during sending error to verifier when the response uri is not available`() {
-        setField(openID4VP, "responseUri", null)
+        setField(openID4VP, "responseDispatchInfo", null)
 
         val errorDispatchFailure: ErrorDispatchFailure = assertThrows<ErrorDispatchFailure> {
             openID4VP.sendErrorInfoToVerifier(AccessDenied("Access denied by user", "OpenID4VPTest"))
@@ -327,7 +327,7 @@ class OpenID4VPTest {
 
         assertOpenId4VPException(
             exception = errorDispatchFailure,
-            expectedMessage = "Failed to send error to verifier: Response URI is not set. Cannot send error to verifier.",
+            expectedMessage = "Failed to send error to verifier: Response dispatch details are not set. Cannot send error to verifier.",
             expectedErrorCode = "error_dispatch_failure"
         )
     }
@@ -463,6 +463,7 @@ class OpenID4VPTest {
 
         val customAuthorizationRequest = createAuthorizationRequestWithState("test-state")
         setField(openID4VP, "authorizationRequest", customAuthorizationRequest)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl, state = "test-state"))
 
         openID4VP.sendErrorInfoToVerifier(InvalidData("With state test", ""))
 
@@ -493,6 +494,7 @@ class OpenID4VPTest {
 
         val customAuthorizationRequest = createAuthorizationRequestWithState("")
         setField(openID4VP, "authorizationRequest", customAuthorizationRequest)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl, state = ""))
 
         openID4VP.sendErrorInfoToVerifier(InvalidData("empty state test", ""))
 
@@ -523,6 +525,7 @@ class OpenID4VPTest {
 
         val noStateAuthorizationRequest = createAuthorizationRequestWithState(null)
         setField(openID4VP, "authorizationRequest", noStateAuthorizationRequest)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl, state = null))
 
         openID4VP.sendErrorInfoToVerifier(InvalidData("No state test", ""))
 
@@ -623,7 +626,7 @@ class OpenID4VPTest {
         ))
 
         every {
-            mockHandler.constructVPResponse(any(), any())
+            mockHandler.constructVPResponse(any(), any(), any())
         } returns mapOf("vp_token" to "<VP>", "presentation_submission" to "<Submission>")
 
         setField(openID4VP, "authorizationResponseHandler", mockHandler)
@@ -636,11 +639,11 @@ class OpenID4VPTest {
     @Test
     fun `should construct error response successfully`() {
         setField(openID4VP, "walletNonce", "iqweutiuq3o4eq-")
-        setField(openID4VP, "responseUri", "https://mock-verifier.com/response-uri")
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo("https://mock-verifier.com/response-uri"))
         val mockHandler = mockk<AuthorizationResponseHandler>()
         setField(openID4VP, "authorizationResponseHandler", mockHandler)
         every {
-            mockHandler.constructAuthorizationErrorResponse(any(), any(), any())
+            mockHandler.constructAuthorizationErrorResponse(any(), any(), any(), any())
         } returns mapOf("error" to "invalid_request", "error_description" to "Unsupported response_mode")
 
         val errorResult =

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/WalletConfigAndNewFeaturesTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/WalletConfigAndNewFeaturesTest.kt
@@ -1,5 +1,7 @@
 package io.mosip.openID4VP
 
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
+
 import io.mockk.*
 import io.mosip.openID4VP.authorizationRequest.*
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequestFieldConstants.*
@@ -73,7 +75,7 @@ class WalletConfigTest {
 
 class GetFallbackForRequestUriTest {
 
-    private val setResponseUri: (String) -> Unit = mockk(relaxed = true)
+    private val setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit = mockk(relaxed = true)
     private val walletNonce = "VbRRB/LTxLiXmVNZuyMO8A=="
 
     @BeforeTest
@@ -121,7 +123,7 @@ class GetFallbackForRequestUriTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
 
@@ -200,7 +202,7 @@ class UnrecognizedClientIdPrefixFallbackTest {
 
 class PreRegisteredProcessValidationTest {
 
-    private val setResponseUri: (String) -> Unit = mockk(relaxed = true)
+    private val setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit = mockk(relaxed = true)
     private val walletNonce = "VbRRB/LTxLiXmVNZuyMO8A=="
 
     @Test
@@ -229,7 +231,7 @@ class PreRegisteredProcessValidationTest {
             SpecVersion.DRAFT_23,
             authorizationRequestParameters,
             walletConfig,
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
@@ -272,7 +274,7 @@ class PreRegisteredProcessValidationTest {
             SpecVersion.DRAFT_23,
             authorizationRequestParameters,
             walletConfig,
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
@@ -314,7 +316,7 @@ class PreRegisteredProcessValidationTest {
             SpecVersion.DRAFT_23,
             authorizationRequestParameters,
             walletConfig,
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
@@ -326,7 +328,7 @@ class PreRegisteredProcessValidationTest {
 
 class RedirectUriProcessTest {
 
-    private val setResponseUri: (String) -> Unit = mockk(relaxed = true)
+    private val setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit = mockk(relaxed = true)
     private val walletNonce = "VbRRB/LTxLiXmVNZuyMO8A=="
 
     @Test
@@ -352,7 +354,7 @@ class RedirectUriProcessTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
 

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestObjectObtainedByReferenceTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestObjectObtainedByReferenceTest.kt
@@ -1,5 +1,7 @@
 package io.mosip.openID4VP.authorizationRequest
 
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
+
 import io.mosip.openID4VP.common.encodeToBase64Url
 import io.mosip.openID4VP.common.decodeFromBase64Url
 import io.mockk.clearAllMocks
@@ -138,7 +140,7 @@ class AuthorizationRequestObjectObtainedByReferenceTest {
             AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 encodedAuthorizationRequest,
                 walletConfig,
-                { _: String -> },
+                { _: ResponseDispatchInfo -> },
                 walletNonce
             )
         }
@@ -166,7 +168,7 @@ class AuthorizationRequestObjectObtainedByReferenceTest {
             AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 encodedAuthorizationRequest,
                 walletConfig,
-                { _: String -> },
+                { _: ResponseDispatchInfo -> },
                 walletNonce
             )
         }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthorizationRequestTest.kt
@@ -1,5 +1,7 @@
 package io.mosip.openID4VP.authorizationRequest
 
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
+
 
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -722,7 +724,7 @@ class AuthorizationRequestTest {
 
     @Test
     fun `should throw invalid request exception if transaction_data is present in Authorization Request`() {
-        val setResponseUri: (String) -> Unit = mockk(relaxed = true)
+        val setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit = mockk(relaxed = true)
 
         val handler = PreRegisteredSchemeAuthorizationRequestHandler(
             clientId = "mock-client",
@@ -730,17 +732,15 @@ class AuthorizationRequestTest {
             authorizationRequestParameters = (requestParams + clientIdOfPreRegistered + mapOf(
                 "transaction_data" to "some_value",
             )) as MutableMap<String, Any>,
-            walletConfig = WalletConfig(
-                trustedVerifiers = listOf(
-                    Verifier(
-                        "mock-client", listOf(
-                            "https://mock-verifier.com/response-uri", "https://verifier.env2.com/responseUri"
-                        ),
-                        "https://mock-verifier.com/.well-known/jwks.json",
-                        true
-                    ))
-            ),
-            setResponseUri = setResponseUri,
+            walletConfig = WalletConfig(trustedVerifiers = listOf(
+                Verifier(
+                    "mock-client", listOf(
+                        "https://mock-verifier.com/response-uri", "https://verifier.env2.com/responseUri"
+                    ),
+                    "https://mock-verifier.com/.well-known/jwks.json",
+                    true
+                ))),
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
 

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestHandlerTest.kt
@@ -1,5 +1,7 @@
 package io.mosip.openID4VP.authorizationRequest.authorizationRequestHandler
 
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
+
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -736,7 +738,7 @@ class ClientIdSchemeBasedAuthorizationRequestHandlerTest {
     private fun createMockHandler(
         authorizationRequestParameters: MutableMap<String, Any>,
         walletConfig: WalletConfig? = null,
-        setResponseUri: (String) -> Unit = {},
+        setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit = {},
         walletNonce: String = "walletNonce",
         specVersion: SpecVersion = SpecVersion.DRAFT_23,
         isSignedRequestSupported: Boolean = true,
@@ -750,7 +752,7 @@ class ClientIdSchemeBasedAuthorizationRequestHandlerTest {
             specVersion = specVersion,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig ?: io.mosip.openID4VP.testData.walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         ) {
             override fun isSignedRequestSupported() = isSignedRequestSupported

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/DidSchemeAuthorizationRequestHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/DidSchemeAuthorizationRequestHandlerTest.kt
@@ -1,5 +1,7 @@
 package io.mosip.openID4VP.authorizationRequest.authorizationRequestHandler.types
 
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
+
 import io.mockk.*
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequestFieldConstants.*
 import io.mosip.openID4VP.authorizationRequest.LdpVpFormatSupported
@@ -24,7 +26,7 @@ class DidSchemeAuthorizationRequestHandlerTest {
 
     private lateinit var authorizationRequestParameters: MutableMap<String, Any>
     private lateinit var walletConfig: WalletConfig
-    private val setResponseUri: (String) -> Unit = mockk(relaxed = true)
+    private val setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit = mockk(relaxed = true)
     val walletNonce = "VbRRB/LTxLiXmVNZuyMO8A=="
 
     @BeforeTest
@@ -58,7 +60,7 @@ class DidSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
 
@@ -74,7 +76,7 @@ class DidSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
 
@@ -105,7 +107,7 @@ class DidSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
 
@@ -124,7 +126,7 @@ class DidSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
         assertTrue(didHandler.confirmSpecVersionIdentifiedFromRequest())
@@ -134,7 +136,7 @@ class DidSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.V1,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
         assertTrue(decentralizedIdentifierHandler.confirmSpecVersionIdentifiedFromRequest())
@@ -144,7 +146,7 @@ class DidSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.V1,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
         assertFalse(mismatchingHandler.confirmSpecVersionIdentifiedFromRequest())

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandlerTest.kt
@@ -1,5 +1,7 @@
 package io.mosip.openID4VP.authorizationRequest.authorizationRequestHandler.types
 
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
+
 import io.mockk.*
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequestFieldConstants.*
 import io.mosip.openID4VP.authorizationRequest.LdpVpFormatSupported
@@ -23,7 +25,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
 
     private lateinit var authorizationRequestParameters: MutableMap<String, Any>
     private lateinit var walletConfig: WalletConfig
-    private val setResponseUri: (String) -> Unit = mockk(relaxed = true)
+    private val setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit = mockk(relaxed = true)
     private val validClientId = "mock-client"
     private var trustedVerifiers: MutableList<Verifier> = mutableListOf(
         Verifier(
@@ -69,7 +71,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             SpecVersion.DRAFT_23,
             authorizationRequestParameters,
             walletConfig,
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
@@ -93,7 +95,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
                 trustedVerifiers = trustedVerifiers,
                 validateTrustedVerifier = false
             ),
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
@@ -112,7 +114,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             SpecVersion.DRAFT_23,
             authorizationRequestParameters,
             walletConfig,
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
@@ -129,7 +131,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             SpecVersion.DRAFT_23,
             authorizationRequestParameters,
             walletConfig,
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
@@ -149,7 +151,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             SpecVersion.DRAFT_23,
             authorizationRequestParameters,
             walletConfig,
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
@@ -178,7 +180,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
                 CLIENT_METADATA.value to clientMetadataString
             )) as MutableMap<String, Any>,
             WalletConfig(trustedVerifiers = trustedVerifiersWithoutClientMetadata),
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
@@ -195,12 +197,12 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             SpecVersion.DRAFT_23,
             authorizationRequestParameters,
             walletConfig,
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
         val exception = assertFailsWith<OpenID4VPExceptions.InvalidData> {
-            handler.setResponseUrl()
+            handler.prepareDispatchInfo()
         }
         assertOpenId4VPException(exception,"redirect_uri should not be present for given response_mode", OpenID4VPErrorCodes.INVALID_REQUEST)
     }
@@ -214,12 +216,12 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             SpecVersion.DRAFT_23,
             authorizationRequestParameters,
             walletConfig,
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
         val exception = assertFailsWith<OpenID4VPExceptions.InvalidData> {
-            handler.setResponseUrl()
+            handler.prepareDispatchInfo()
         }
         assertOpenId4VPException(exception,"redirect_uri should not be present for given response_mode", OpenID4VPErrorCodes.INVALID_REQUEST)
     }
@@ -233,7 +235,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             SpecVersion.DRAFT_23,
             authorizationRequestParameters,
             walletConfig,
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
@@ -251,7 +253,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             SpecVersion.DRAFT_23,
             authorizationRequestParameters,
             walletConfig,
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
@@ -275,7 +277,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
                 trustedVerifiers = trustedVerifiers,
                 validateTrustedVerifier = false
             ),
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
@@ -297,7 +299,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
 
@@ -321,7 +323,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
 
@@ -341,7 +343,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = WalletConfig(trustedVerifiers = trustedVerifiers),
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
 
@@ -363,7 +365,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
 
@@ -384,7 +386,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
 
@@ -407,7 +409,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = WalletConfig(trustedVerifiers = trustedVerifiers),
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
 
@@ -429,7 +431,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = WalletConfig(trustedVerifiers = trustedVerifiers),
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
 
@@ -446,7 +448,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             SpecVersion.DRAFT_23,
             authorizationRequestParameters,
             walletConfig,
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
 
@@ -465,7 +467,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
                 trustedVerifiers = trustedVerifiers,
                 validateTrustedVerifier = false
             ),
-            setResponseUri,
+            setResponseDispatchInfo,
             walletNonce
         )
         assertTrue(handler.isUnsignedRequestSupported())
@@ -479,7 +481,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
         val ex = assertFailsWith<OpenID4VPExceptions.InvalidVerifier> {
@@ -501,7 +503,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters.apply { put(CLIENT_ID.value, "test-client") },
             walletConfig = WalletConfig(trustedVerifiers = listOf(verifier)),
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
         assertFalse(handler.isUnsignedRequestSupported())
@@ -520,7 +522,7 @@ class PreRegisteredSchemeAuthorizationRequestHandlerTest {
             specVersion = SpecVersion.DRAFT_23,
             authorizationRequestParameters = authorizationRequestParameters.apply { put(CLIENT_ID.value, "test-client") },
             walletConfig = WalletConfig(trustedVerifiers = listOf(verifier)),
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
         assertTrue(handler.isUnsignedRequestSupported())

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationRequest/authorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandlerTest.kt
@@ -1,5 +1,7 @@
 package io.mosip.openID4VP.authorizationRequest.authorizationRequestHandler.types
 
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
+
 import io.mockk.*
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequestFieldConstants.*
 import io.mosip.openID4VP.authorizationRequest.LdpVpFormatSupported
@@ -23,7 +25,7 @@ class RedirectUriPrefixAuthorizationRequestHandlerTest {
 
     private lateinit var authorizationRequestParameters: MutableMap<String, Any>
     private lateinit var walletConfig: WalletConfig
-    private val setResponseUri: (String) -> Unit = mockk(relaxed = true)
+    private val setResponseDispatchInfo: (ResponseDispatchInfo) -> Unit = mockk(relaxed = true)
     val walletNonce = "VbRRB/LTxLiXmVNZuyMO8A=="
 
     @BeforeTest
@@ -56,7 +58,7 @@ class RedirectUriPrefixAuthorizationRequestHandlerTest {
             specVersion = specVersion,
             authorizationRequestParameters = params,
             walletConfig = walletConfig,
-            setResponseUri = setResponseUri,
+            setResponseDispatchInfo = setResponseDispatchInfo,
             walletNonce = walletNonce
         )
 
@@ -215,7 +217,7 @@ class RedirectUriPrefixAuthorizationRequestHandlerTest {
         val modifiedParams = authorizationRequestParameters.toMutableMap()
         modifiedParams[REDIRECT_URI.value] = "https://example.com/redirect"
         val exception = assertFailsWith<OpenID4VPExceptions.InvalidData> {
-            createHandler(modifiedParams).setResponseUrl()
+            createHandler(modifiedParams).prepareDispatchInfo()
         }
         assertTrue(exception.message?.contains("redirect_uri should not be present") == true)
     }
@@ -226,7 +228,7 @@ class RedirectUriPrefixAuthorizationRequestHandlerTest {
         modifiedParams[RESPONSE_MODE.value] = "direct_post.jwt"
         modifiedParams[REDIRECT_URI.value] = "https://example.com/redirect"
         val exception = assertFailsWith<OpenID4VPExceptions.InvalidData> {
-            createHandler(modifiedParams).setResponseUrl()
+            createHandler(modifiedParams).prepareDispatchInfo()
         }
         assertTrue(exception.message?.contains("redirect_uri should not be present") == true)
     }

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerTest.kt
@@ -29,8 +29,11 @@ import io.mosip.openID4VP.dcql.query.DCQLQuery
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions.*
 import io.mosip.openID4VP.networkManager.NetworkManagerClient
 import io.mosip.openID4VP.networkManager.NetworkResponse
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
+import io.mosip.openID4VP.responseModeHandler.ResponseEncryptionSpecification
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandler
 import io.mosip.openID4VP.responseModeHandler.ResponseModeBasedHandlerFactory
+import io.mosip.openID4VP.responseModeHandler.types.DirectPostResponseModeHandler
 import io.mosip.openID4VP.testData.*
 import io.mosip.openID4VP.wallet.Credential
 import java.io.IOException
@@ -74,6 +77,20 @@ class AuthorizationResponseHandlerTest {
 
     private lateinit var authorizationResponseHandler: AuthorizationResponseHandler
     private val mockResponseHandler = mockk<ResponseModeBasedHandler>()
+
+    private fun dispatchInfoFor(
+        request: AuthorizationRequest = authorizationPresentationExchangeRequest,
+        responseUrl: String = request.responseUri ?: "https://mock-verifier.com",
+        encryptionSpecification: ResponseEncryptionSpecification? = null
+    ) = ResponseDispatchInfo(
+        responseMode = request.responseMode ?: "direct_post",
+        nonce = request.nonce,
+        walletNonce = request.walletNonce,
+        state = request.state,
+        clientId = request.clientId,
+        responseUrl = responseUrl,
+        responseEncryptionSpecification = encryptionSpecification
+    )
 
     @BeforeTest
     fun setUp() {
@@ -234,14 +251,13 @@ class AuthorizationResponseHandlerTest {
         mockkObject(ResponseModeBasedHandlerFactory)
         every { ResponseModeBasedHandlerFactory.get(any()) } returns mockResponseHandler
         every {
-            mockResponseHandler.sendAuthorizationResponse(
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
+            mockResponseHandler.sendAuthorizationResponse(any(), any(), any())
         } returns NetworkResponse(200, "{\"message\":\"success\"}", mapOf())
+        every {
+            mockResponseHandler.sendAuthorizationError(any(), any(), any())
+        } answers {
+            DirectPostResponseModeHandler().sendAuthorizationError(firstArg(), secondArg(), thirdArg())
+        }
     }
 
     @AfterTest
@@ -337,7 +353,7 @@ class AuthorizationResponseHandlerTest {
                         signedData = "mock-signed-data".toByteArray()
                     )
                 ),
-                responseUri = authorizationPresentationExchangeRequest.responseUri!!
+                dispatchInfo = dispatchInfoFor(request = request, responseUrl = authorizationPresentationExchangeRequest.responseUri!!)
             )
         }
         assertEquals("server_error", exception.errorCode)
@@ -371,7 +387,7 @@ class AuthorizationResponseHandlerTest {
                         signedData = "mock-signed-data".toByteArray()
                     )
                 ),
-                responseUri = authorizationPresentationExchangeRequest.responseUri!!
+                dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest, responseUrl = authorizationPresentationExchangeRequest.responseUri!!)
             )
         }
         assertEquals("server_error", exception.errorCode)
@@ -425,7 +441,7 @@ class AuthorizationResponseHandlerTest {
                     signedData = "mock-ldp-signed".toByteArray()
                 )
             ),
-            responseUri = responseUrl
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest, responseUrl = responseUrl)
         )
 
         assertEquals("{\"message\":\"success\"}", result.additionalParams)
@@ -433,11 +449,9 @@ class AuthorizationResponseHandlerTest {
         verify {
             ResponseModeBasedHandlerFactory.get("direct_post")
             mockResponseHandler.sendAuthorizationResponse(
-                authorizationRequest = authorizationPresentationExchangeRequest,
-                url = responseUrl,
+                dispatchInfo = any(),
                 authorizationResponse = any(),
-                walletNonce = any(),
-                walletConfig = any()
+                authorizationRequest = authorizationPresentationExchangeRequest
             )
         }
     }
@@ -464,7 +478,7 @@ class AuthorizationResponseHandlerTest {
                         signedData = "mock-signed-data".toByteArray()
                     )
                 ),
-                responseUri = responseUrl
+                dispatchInfo = dispatchInfoFor(responseUrl = responseUrl)
             )
         }
         assertEquals("server_error", exception.errorCode)
@@ -510,7 +524,7 @@ class AuthorizationResponseHandlerTest {
                         signedData = "mock-signed-1".toByteArray()
                     )
                 ),
-                responseUri = responseUrl
+                dispatchInfo = dispatchInfoFor(request = request, responseUrl = responseUrl)
             )
         }
         assertEquals("Unsupported response mode: unsupported_mode", exception.message)
@@ -539,7 +553,7 @@ class AuthorizationResponseHandlerTest {
                         signedData = "mock-signed-data".toByteArray()
                     )
                 ),
-                responseUri = responseUrl
+                dispatchInfo = dispatchInfoFor(responseUrl = responseUrl)
             )
         }
         assertEquals("server_error", exception.errorCode)
@@ -577,7 +591,7 @@ class AuthorizationResponseHandlerTest {
                         signedData = "extra-signed-data".toByteArray()
                     )
                 ),
-                responseUri = responseUrl
+                dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest, responseUrl = responseUrl)
             )
         }
         assertEquals("server_error", exception.errorCode)
@@ -595,7 +609,7 @@ class AuthorizationResponseHandlerTest {
     @Test
     fun `should throw exception when network error occurs during response sending`() {
         every {
-            mockResponseHandler.sendAuthorizationResponse(any(), any(), any(), any(), any())
+            mockResponseHandler.sendAuthorizationResponse(any(), any(), any())
         } throws IOException("Network connection failed")
 
         authorizationResponseHandler.constructUnsignedVPToken(
@@ -614,7 +628,7 @@ class AuthorizationResponseHandlerTest {
                         signedData = "mock-signed-1".toByteArray()
                     )
                 ),
-                responseUri = responseUrl
+                dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest, responseUrl = responseUrl)
             )
         }
         assertEquals("Network connection failed", exception.message)
@@ -769,7 +783,7 @@ class AuthorizationResponseHandlerTest {
                     signedData = "mock-sd-jwt-signed".toByteArray()
                 )
             ),
-            responseUri = responseUrl
+            dispatchInfo = dispatchInfoFor(request = request, responseUrl = responseUrl)
         )
 
         assertEquals("{\"message\":\"success\"}", result.additionalParams)
@@ -777,11 +791,9 @@ class AuthorizationResponseHandlerTest {
 
         verify(exactly = 1) {
             mockResponseHandler.sendAuthorizationResponse(
-                authorizationRequest = any(),
-                url = eq(responseUrl),
+                dispatchInfo = any(),
                 authorizationResponse = any(),
-                walletNonce = any(),
-                walletConfig = any()
+                authorizationRequest = any()
             )
         }
 
@@ -817,7 +829,7 @@ class AuthorizationResponseHandlerTest {
                         signedData = "mock-signed-data".toByteArray()
                     )
                 ),
-                responseUrl
+                dispatchInfoFor(request = request, responseUrl = responseUrl)
             )
         }
         assertEquals("server_error", exception.errorCode)
@@ -884,7 +896,7 @@ class AuthorizationResponseHandlerTest {
                     signedData = "mock-signed-1".toByteArray()
                 )
             ),
-            responseUrl
+            dispatchInfoFor(request = request, responseUrl = responseUrl)
         )
 
         assertEquals("{\"message\":\"success\"}", result.additionalParams)
@@ -935,14 +947,13 @@ class AuthorizationResponseHandlerTest {
                     signedData = "mock-mdoc-signed".toByteArray()
                 ),
             ),
-            responseUri = responseUrl
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest, responseUrl = responseUrl)
         )
 
         // assert if mockResponseHandler is called with correct authorization response
         verify(exactly = 1) {
             mockResponseHandler.sendAuthorizationResponse(
-                authorizationRequest = any(),
-                url = eq(responseUrl),
+                dispatchInfo = any(),
                 authorizationResponse = match {
                     val pe = it as AuthorizationResponse.PresentationExchange
                     // Note: If only one vp token is being shared then tha path in the presentation submission takes value as $ and VP token is an element only and not array
@@ -956,8 +967,7 @@ class AuthorizationResponseHandlerTest {
                     )
                     pe.presentationSubmission.descriptorMap.size == 1
                 },
-                walletNonce = any(),
-                walletConfig = any()
+                authorizationRequest = any()
             )
         }
     }
@@ -1114,15 +1124,14 @@ class AuthorizationResponseHandlerTest {
                     signedData = "mock-sdjwt-signed".toByteArray()
                 )
             ),
-            responseUri = responseUrl
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest, responseUrl = responseUrl)
         )
 
         assertEquals("{\"message\":\"success\"}", result.additionalParams)
         // assert if mockResponseHandler is called with correct authorization response
         verify(exactly = 1) {
             mockResponseHandler.sendAuthorizationResponse(
-                authorizationRequest = any(),
-                url = eq(responseUrl),
+                dispatchInfo = any(),
                 authorizationResponse = match {
                     val pe = it as AuthorizationResponse.PresentationExchange
                     // Note: If only more than vp token is being shared then the path in presentation submission takes value as $[<index>] and VP token is an array holding all tokens together
@@ -1133,8 +1142,7 @@ class AuthorizationResponseHandlerTest {
                     )
                     true
                 },
-                walletNonce = any(),
-                walletConfig = any()
+                authorizationRequest = any()
             )
         }
     }
@@ -1159,7 +1167,7 @@ class AuthorizationResponseHandlerTest {
 
         val ex = InvalidData("Some invalid data", "TestClass")
         val result = authorizationResponseHandler.sendAuthorizationError(
-            responseUri = "https://verifier.example.com/cb",
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest, responseUrl = "https://verifier.example.com/cb"),
             authorizationRequest = authorizationPresentationExchangeRequest,
             exception = ex
         )
@@ -1184,7 +1192,7 @@ class AuthorizationResponseHandlerTest {
 
         val ex = RuntimeException("Boom")
         val result = authorizationResponseHandler.sendAuthorizationError(
-            responseUri = "https://verifier.example.com/cb",
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest, responseUrl = "https://verifier.example.com/cb"),
             authorizationRequest = authorizationPresentationExchangeRequest,
             exception = ex
         )
@@ -1199,7 +1207,7 @@ class AuthorizationResponseHandlerTest {
         val ex = InvalidData("msg", "Test")
         assertFailsWith<ErrorDispatchFailure> {
             authorizationResponseHandler.sendAuthorizationError(
-                responseUri = null,
+                dispatchInfo = null,
                 authorizationRequest = authorizationPresentationExchangeRequest,
                 exception = ex
             )
@@ -1215,7 +1223,7 @@ class AuthorizationResponseHandlerTest {
         val ex = InvalidData("msg", "Test")
         val failure = assertFailsWith<ErrorDispatchFailure> {
             authorizationResponseHandler.sendAuthorizationError(
-                responseUri = "https://verifier.example.com/cb",
+                dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest, responseUrl = "https://verifier.example.com/cb"),
                 authorizationRequest = authorizationPresentationExchangeRequest,
                 exception = ex
             )
@@ -1230,9 +1238,9 @@ class AuthorizationResponseHandlerTest {
         every { ResponseModeBasedHandlerFactory.get("direct_post") } returns mockResponseHandler
         every {
             mockResponseHandler.getAuthorizationErrorResponse(
-                authorizationRequest = any<AuthorizationRequest>(),
+                dispatchInfo = any(),
                 authorizationResponse = any<AuthorizationErrorResponse>(),
-                walletNonce = any<String>()
+                authorizationRequest = any<AuthorizationRequest>()
             )
         } returns mapOf(
             "error" to "invalid_request",
@@ -1242,9 +1250,10 @@ class AuthorizationResponseHandlerTest {
         val exception = InvalidData("Invalid data provided", "TestClass")
 
         val result = authorizationResponseHandler.constructAuthorizationErrorResponse(
-            authorizationRequest = authorizationPresentationExchangeRequest,
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest),
             exception = exception,
-            walletNonce = "wallet-nonce-value"
+            walletNonce = "wallet-nonce-value",
+            authorizationRequest = authorizationPresentationExchangeRequest
         )
 
         assertEquals(
@@ -1256,9 +1265,9 @@ class AuthorizationResponseHandlerTest {
 
         verify {
             mockResponseHandler.getAuthorizationErrorResponse(
-                authorizationRequest = authorizationPresentationExchangeRequest,
+                dispatchInfo = any(),
                 authorizationResponse = any<AuthorizationErrorResponse>(),
-                walletNonce = any<String>()
+                authorizationRequest = authorizationPresentationExchangeRequest
             )
         }
     }
@@ -1269,18 +1278,19 @@ class AuthorizationResponseHandlerTest {
         every { ResponseModeBasedHandlerFactory.get("direct_post") } returns mockResponseHandler
         every {
             mockResponseHandler.getAuthorizationErrorResponse(
-                authorizationRequest = any<AuthorizationRequest>(),
+                dispatchInfo = any(),
                 authorizationResponse = any<AuthorizationErrorResponse>(),
-                walletNonce = any<String>()
+                authorizationRequest = any<AuthorizationRequest>()
             )
         } returns mapOf("error" to "access_denied")
 
         val exception = AccessDenied("Access denied to resource", "TestClass")
 
         val result = authorizationResponseHandler.constructAuthorizationErrorResponse(
-            authorizationRequest = authorizationPresentationExchangeRequest,
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest),
             exception = exception,
-            walletNonce = "wallet-nonce-value"
+            walletNonce = "wallet-nonce-value",
+            authorizationRequest = authorizationPresentationExchangeRequest
         )
 
         assertEquals(mapOf("error" to "access_denied"), result)
@@ -1292,18 +1302,19 @@ class AuthorizationResponseHandlerTest {
         every { ResponseModeBasedHandlerFactory.get("direct_post") } returns mockResponseHandler
         every {
             mockResponseHandler.getAuthorizationErrorResponse(
-                authorizationRequest = any<AuthorizationRequest>(),
+                dispatchInfo = any(),
                 authorizationResponse = any<AuthorizationErrorResponse>(),
-                walletNonce = any<String>()
+                authorizationRequest = any<AuthorizationRequest>()
             )
         } returns mapOf("error" to "invalid_client")
 
         val exception = InvalidVerifier("Invalid verifier provided", "TestClass")
 
         val result = authorizationResponseHandler.constructAuthorizationErrorResponse(
-            authorizationRequest = authorizationPresentationExchangeRequest,
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest),
             exception = exception,
-            walletNonce = "wallet-nonce-value"
+            walletNonce = "wallet-nonce-value",
+            authorizationRequest = authorizationPresentationExchangeRequest
         )
 
         assertEquals(mapOf("error" to "invalid_client"), result)
@@ -1315,18 +1326,19 @@ class AuthorizationResponseHandlerTest {
         every { ResponseModeBasedHandlerFactory.get("direct_post") } returns mockResponseHandler
         every {
             mockResponseHandler.getAuthorizationErrorResponse(
-                authorizationRequest = any<AuthorizationRequest>(),
+                dispatchInfo = any(),
                 authorizationResponse = any<AuthorizationErrorResponse>(),
-                walletNonce = any<String>()
+                authorizationRequest = any<AuthorizationRequest>()
             )
         } returns mapOf("error" to "server_error")
 
         val genericException = RuntimeException("Unexpected runtime error")
 
         val result = authorizationResponseHandler.constructAuthorizationErrorResponse(
-            authorizationRequest = authorizationPresentationExchangeRequest,
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest),
             exception = genericException,
-            walletNonce = "wallet-nonce-value"
+            walletNonce = "wallet-nonce-value",
+            authorizationRequest = authorizationPresentationExchangeRequest
         )
 
         assertEquals(mapOf("error" to "server_error"), result)
@@ -1338,18 +1350,19 @@ class AuthorizationResponseHandlerTest {
         every { ResponseModeBasedHandlerFactory.get("direct_post") } returns mockResponseHandler
         every {
             mockResponseHandler.getAuthorizationErrorResponse(
-                authorizationRequest = any<AuthorizationRequest>(),
+                dispatchInfo = any(),
                 authorizationResponse = any<AuthorizationErrorResponse>(),
-                walletNonce = any<String>()
+                authorizationRequest = any<AuthorizationRequest>()
             )
         } returns mapOf("error" to "server_error")
 
         val exceptionWithNullMessage = RuntimeException(null as String?)
 
         val result = authorizationResponseHandler.constructAuthorizationErrorResponse(
-            authorizationRequest = authorizationPresentationExchangeRequest,
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest),
             exception = exceptionWithNullMessage,
-            walletNonce = "wallet-nonce-value"
+            walletNonce = "wallet-nonce-value",
+            authorizationRequest = authorizationPresentationExchangeRequest
         )
 
         assertEquals(mapOf("error" to "server_error"), result)
@@ -1363,18 +1376,19 @@ class AuthorizationResponseHandlerTest {
         val capturedErrorResponse = slot<AuthorizationErrorResponse>()
         every {
             mockResponseHandler.getAuthorizationErrorResponse(
-                authorizationRequest = authorizationPresentationExchangeRequest,
+                dispatchInfo = any(),
                 authorizationResponse = capture(capturedErrorResponse),
-                walletNonce = any<String>()
+                authorizationRequest = authorizationPresentationExchangeRequest
             )
         } returns mapOf("state" to "preserved")
 
         val exception = InvalidData("Test error", "TestClass")
 
         authorizationResponseHandler.constructAuthorizationErrorResponse(
-            authorizationRequest = authorizationPresentationExchangeRequest,
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest),
             exception = exception,
-            walletNonce = "wallet-nonce-value"
+            walletNonce = "wallet-nonce-value",
+            authorizationRequest = authorizationPresentationExchangeRequest
         )
 
         assertEquals(
@@ -1391,18 +1405,19 @@ class AuthorizationResponseHandlerTest {
         every { ResponseModeBasedHandlerFactory.get("direct_post.jwt") } returns mockResponseHandler
         every {
             mockResponseHandler.getAuthorizationErrorResponse(
-                authorizationRequest = any<AuthorizationRequest>(),
+                dispatchInfo = any(),
                 authorizationResponse = any<AuthorizationErrorResponse>(),
-                walletNonce = any<String>()
+                authorizationRequest = any<AuthorizationRequest>()
             )
         } returns mapOf("jwt" to "encrypted_response")
 
         val exception = InvalidTransactionData("Invalid transaction", "TestClass")
 
         val result = authorizationResponseHandler.constructAuthorizationErrorResponse(
-            authorizationRequest = jwtRequest,
+            dispatchInfo = dispatchInfoFor(request = jwtRequest),
             exception = exception,
-            walletNonce = "wallet-nonce-value"
+            walletNonce = "wallet-nonce-value",
+            authorizationRequest = jwtRequest
         )
 
         assertEquals(mapOf("jwt" to "encrypted_response"), result)
@@ -1414,9 +1429,9 @@ class AuthorizationResponseHandlerTest {
         every { ResponseModeBasedHandlerFactory.get("direct_post") } returns mockResponseHandler
         every {
             mockResponseHandler.getAuthorizationErrorResponse(
-                authorizationRequest = any<AuthorizationRequest>(),
+                dispatchInfo = any(),
                 authorizationResponse = any<AuthorizationErrorResponse>(),
-                walletNonce = any<String>()
+                authorizationRequest = any<AuthorizationRequest>()
             )
         } returns mapOf("error" to "invalid_request")
 
@@ -1427,9 +1442,10 @@ class AuthorizationResponseHandlerTest {
         )
 
         val result = authorizationResponseHandler.constructAuthorizationErrorResponse(
-            authorizationRequest = authorizationPresentationExchangeRequest,
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest),
             exception = exception,
-            walletNonce = "wallet-nonce-value"
+            walletNonce = "wallet-nonce-value",
+            authorizationRequest = authorizationPresentationExchangeRequest
         )
 
         assertEquals(mapOf("error" to "invalid_request"), result)
@@ -1441,18 +1457,19 @@ class AuthorizationResponseHandlerTest {
         every { ResponseModeBasedHandlerFactory.get("direct_post") } returns mockResponseHandler
         every {
             mockResponseHandler.getAuthorizationErrorResponse(
-                authorizationRequest = any<AuthorizationRequest>(),
+                dispatchInfo = any(),
                 authorizationResponse = any<AuthorizationErrorResponse>(),
-                walletNonce = any<String>()
+                authorizationRequest = any<AuthorizationRequest>()
             )
         } returns mapOf("error" to "invalid_request")
 
         val exception = InvalidInputPattern(listOf("path", "to", "field"), "TestClass")
 
         val result = authorizationResponseHandler.constructAuthorizationErrorResponse(
-            authorizationRequest = authorizationPresentationExchangeRequest,
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest),
             exception = exception,
-            walletNonce = "wallet-nonce-value"
+            walletNonce = "wallet-nonce-value",
+            authorizationRequest = authorizationPresentationExchangeRequest
         )
 
         assertEquals(mapOf("error" to "invalid_request"), result)
@@ -1464,18 +1481,19 @@ class AuthorizationResponseHandlerTest {
         every { ResponseModeBasedHandlerFactory.get("direct_post") } returns mockResponseHandler
         every {
             mockResponseHandler.getAuthorizationErrorResponse(
-                authorizationRequest = any<AuthorizationRequest>(),
+                dispatchInfo = any(),
                 authorizationResponse = any<AuthorizationErrorResponse>(),
-                walletNonce = any<String>()
+                authorizationRequest = any<AuthorizationRequest>()
             )
         } returns mapOf("error" to "invalid_request")
 
         val exception = JsonEncodingFailed("fieldPath", "JSON encoding error", "TestClass")
 
         val result = authorizationResponseHandler.constructAuthorizationErrorResponse(
-            authorizationRequest = authorizationPresentationExchangeRequest,
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest),
             exception = exception,
-            walletNonce = "wallet-nonce-value"
+            walletNonce = "wallet-nonce-value",
+            authorizationRequest = authorizationPresentationExchangeRequest
         )
 
         assertEquals(mapOf("error" to "invalid_request"), result)
@@ -1490,10 +1508,9 @@ class AuthorizationResponseHandlerTest {
         every { ResponseModeBasedHandlerFactory.get("direct_post") } returns mockResponseHandler
         every {
             mockResponseHandler.getAuthorizationResponse(
-                authorizationRequest = any<AuthorizationRequest>(),
+                dispatchInfo = any(),
                 authorizationResponse = any<AuthorizationResponse>(),
-                walletNonce = any<String>(),
-                walletConfig = any()
+                authorizationRequest = any<AuthorizationRequest>()
             )
         } returns mapOf(
             "response" to "finalized",
@@ -1515,7 +1532,8 @@ class AuthorizationResponseHandlerTest {
                     signedData = "mock-signed-data".toByteArray()
                 )
             ),
-            authorizationRequest = authorizationPresentationExchangeRequest
+            authorizationRequest = authorizationPresentationExchangeRequest,
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest)
         )
 
         assertEquals(
@@ -1528,10 +1546,9 @@ class AuthorizationResponseHandlerTest {
 
         verify {
             mockResponseHandler.getAuthorizationResponse(
-                authorizationRequest = authorizationPresentationExchangeRequest,
+                dispatchInfo = any(),
                 authorizationResponse = any<AuthorizationResponse>(),
-                walletNonce = any<String>(),
-                walletConfig = any()
+                authorizationRequest = authorizationPresentationExchangeRequest
             )
         }
     }
@@ -1544,10 +1561,9 @@ class AuthorizationResponseHandlerTest {
         val capturedResponse = slot<AuthorizationResponse>()
         every {
             mockResponseHandler.getAuthorizationResponse(
-                authorizationRequest = authorizationPresentationExchangeRequest,
+                dispatchInfo = any(),
                 authorizationResponse = capture(capturedResponse),
-                walletNonce = any<String>(),
-                walletConfig = any()
+                authorizationRequest = authorizationPresentationExchangeRequest
             )
         } returns mapOf("multi_format" to "response")
 
@@ -1566,7 +1582,8 @@ class AuthorizationResponseHandlerTest {
                     signedData = "mock-signed-1".toByteArray()
                 )
             ),
-            authorizationRequest = authorizationPresentationExchangeRequest
+            authorizationRequest = authorizationPresentationExchangeRequest,
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest)
         )
 
         assertEquals(mapOf("multi_format" to "response"), result)
@@ -1587,10 +1604,9 @@ class AuthorizationResponseHandlerTest {
         every { ResponseModeBasedHandlerFactory.get("direct_post.jwt") } returns mockResponseHandler
         every {
             mockResponseHandler.getAuthorizationResponse(
-                authorizationRequest = any<AuthorizationRequest>(),
+                dispatchInfo = any(),
                 authorizationResponse = any<AuthorizationResponse>(),
-                walletNonce = any<String>(),
-                walletConfig = any()
+                authorizationRequest = any<AuthorizationRequest>()
             )
         } returns mapOf("encrypted" to "jwt_response")
 
@@ -1609,7 +1625,8 @@ class AuthorizationResponseHandlerTest {
                     signedData = "mock-signed-data".toByteArray()
                 )
             ),
-            authorizationRequest = jwtRequest
+            authorizationRequest = jwtRequest,
+            dispatchInfo = dispatchInfoFor(request = jwtRequest)
         )
 
         assertEquals(mapOf("encrypted" to "jwt_response"), result)
@@ -1646,7 +1663,8 @@ class AuthorizationResponseHandlerTest {
                         signedData = "mock-signed-data".toByteArray()
                     )
                 ),
-                authorizationRequest = invalidRequest
+                authorizationRequest = invalidRequest,
+                dispatchInfo = dispatchInfoFor(request = invalidRequest)
             )
         }
         assertEquals("server_error", exception.errorCode)
@@ -1694,7 +1712,8 @@ class AuthorizationResponseHandlerTest {
                         signedData = "mock-signed-data".toByteArray()
                     )
                 ),
-                authorizationRequest = authorizationPresentationExchangeRequest
+                authorizationRequest = authorizationPresentationExchangeRequest,
+                dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest)
             )
         }
         assertEquals("server_error", exception.errorCode)
@@ -1727,10 +1746,9 @@ class AuthorizationResponseHandlerTest {
         val capturedResponse = slot<AuthorizationResponse>()
         every {
             mockResponseHandler.getAuthorizationResponse(
-                authorizationRequest = requestWithState,
+                dispatchInfo = any(),
                 authorizationResponse = capture(capturedResponse),
-                walletNonce = any<String>(),
-                walletConfig = any()
+                authorizationRequest = requestWithState
             )
         } returns mapOf("state" to "test-state-value")
 
@@ -1749,7 +1767,8 @@ class AuthorizationResponseHandlerTest {
                     signedData = "mock-signed-data".toByteArray()
                 )
             ),
-            authorizationRequest = requestWithState
+            authorizationRequest = requestWithState,
+            dispatchInfo = dispatchInfoFor(request = requestWithState)
         )
 
         assertEquals("test-state-value", capturedResponse.captured.state)
@@ -1776,10 +1795,9 @@ class AuthorizationResponseHandlerTest {
         val capturedResponse = slot<AuthorizationResponse>()
         every {
             mockResponseHandler.getAuthorizationResponse(
-                authorizationRequest = requestWithNullState,
+                dispatchInfo = any(),
                 authorizationResponse = capture(capturedResponse),
-                walletNonce = any<String>(),
-                walletConfig = any()
+                authorizationRequest = requestWithNullState
             )
         } returns mapOf("response" to "no_state")
 
@@ -1798,7 +1816,8 @@ class AuthorizationResponseHandlerTest {
                     signedData = "mock-signed-data".toByteArray()
                 )
             ),
-            authorizationRequest = requestWithNullState
+            authorizationRequest = requestWithNullState,
+            dispatchInfo = dispatchInfoFor(request = requestWithNullState)
         )
 
         assertNull(capturedResponse.captured.state)
@@ -1812,10 +1831,9 @@ class AuthorizationResponseHandlerTest {
         val capturedResponse = slot<AuthorizationResponse>()
         every {
             mockResponseHandler.getAuthorizationResponse(
-                authorizationRequest = authorizationPresentationExchangeRequest,
+                dispatchInfo = any(),
                 authorizationResponse = capture(capturedResponse),
-                walletNonce = any<String>(),
-                walletConfig = any()
+                authorizationRequest = authorizationPresentationExchangeRequest
             )
         } returns mapOf("single" to "vp_token")
 
@@ -1834,7 +1852,8 @@ class AuthorizationResponseHandlerTest {
                     signedData = "mock-signed-data".toByteArray()
                 )
             ),
-            authorizationRequest = authorizationPresentationExchangeRequest
+            authorizationRequest = authorizationPresentationExchangeRequest,
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest)
         )
 
         // Verify that vpToken is a VPTokenElement (single token) not VPTokenArray
@@ -1850,10 +1869,9 @@ class AuthorizationResponseHandlerTest {
         val capturedResponse = slot<AuthorizationResponse>()
         every {
             mockResponseHandler.getAuthorizationResponse(
-                authorizationRequest = authorizationPresentationExchangeRequest,
+                dispatchInfo = any(),
                 authorizationResponse = capture(capturedResponse),
-                walletNonce = any<String>(),
-                walletConfig = any()
+                authorizationRequest = authorizationPresentationExchangeRequest
             )
         } returns mapOf("multiple" to "vp_tokens")
 
@@ -1872,7 +1890,8 @@ class AuthorizationResponseHandlerTest {
                     signedData = "mock-signed-1".toByteArray()
                 )
             ),
-            authorizationRequest = authorizationPresentationExchangeRequest
+            authorizationRequest = authorizationPresentationExchangeRequest,
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest)
         )
 
         // Verify that vpToken is a VPTokenArray (multiple tokens)
@@ -1888,10 +1907,9 @@ class AuthorizationResponseHandlerTest {
         val capturedResponse = slot<AuthorizationResponse>()
         every {
             mockResponseHandler.getAuthorizationResponse(
-                authorizationRequest = authorizationPresentationExchangeRequest,
+                dispatchInfo = any(),
                 authorizationResponse = capture(capturedResponse),
-                walletNonce = any<String>(),
-                walletConfig = any()
+                authorizationRequest = authorizationPresentationExchangeRequest
             )
         } returns mapOf("presentation" to "submission")
 
@@ -1910,7 +1928,8 @@ class AuthorizationResponseHandlerTest {
                     signedData = "mock-signed-data".toByteArray()
                 )
             ),
-            authorizationRequest = authorizationPresentationExchangeRequest
+            authorizationRequest = authorizationPresentationExchangeRequest,
+            dispatchInfo = dispatchInfoFor(request = authorizationPresentationExchangeRequest)
         )
 
         val pe = capturedResponse.captured as AuthorizationResponse.PresentationExchange
@@ -2326,10 +2345,9 @@ class AuthorizationResponseHandlerTest {
         val capturedResponse = slot<AuthorizationResponse>()
         every {
             mockResponseHandler.getAuthorizationResponse(
-                authorizationRequest = any(),
+                dispatchInfo = any(),
                 authorizationResponse = capture(capturedResponse),
-                walletNonce = any<String>(),
-                walletConfig = any()
+                authorizationRequest = any()
             )
         } returns mapOf("dcql_response" to "success")
 
@@ -2340,7 +2358,8 @@ class AuthorizationResponseHandlerTest {
 
         val result = authorizationResponseHandler.constructVPResponse(
             vpTokenSigningResults = signingResults,
-            authorizationRequest = dcqlRequest
+            authorizationRequest = dcqlRequest,
+            dispatchInfo = dispatchInfoFor(request = dcqlRequest)
         )
 
         // Verify the response was constructed successfully
@@ -2404,10 +2423,9 @@ class AuthorizationResponseHandlerTest {
         val capturedResponse = slot<AuthorizationResponse>()
         every {
             mockResponseHandler.getAuthorizationResponse(
-                authorizationRequest = any(),
+                dispatchInfo = any(),
                 authorizationResponse = capture(capturedResponse),
-                walletNonce = any<String>(),
-                walletConfig = any()
+                authorizationRequest = any()
             )
         } returns mapOf("multi_dcql" to "success")
 
@@ -2417,7 +2435,8 @@ class AuthorizationResponseHandlerTest {
 
         val result = authorizationResponseHandler.constructVPResponse(
             vpTokenSigningResults = signingResults,
-            authorizationRequest = dcqlRequest
+            authorizationRequest = dcqlRequest,
+            dispatchInfo = dispatchInfoFor(request = dcqlRequest)
         )
 
         assertEquals(mapOf("multi_dcql" to "success"), result)
@@ -2455,10 +2474,9 @@ class AuthorizationResponseHandlerTest {
         val capturedResponse = slot<AuthorizationResponse>()
         every {
             mockResponseHandler.getAuthorizationResponse(
-                authorizationRequest = any(),
+                dispatchInfo = any(),
                 authorizationResponse = capture(capturedResponse),
-                walletNonce = any<String>(),
-                walletConfig = any()
+                authorizationRequest = any()
             )
         } returns mapOf("mixed_dcql" to "success")
 
@@ -2468,7 +2486,8 @@ class AuthorizationResponseHandlerTest {
 
         val result = authorizationResponseHandler.constructVPResponse(
             vpTokenSigningResults = signingResults,
-            authorizationRequest = dcqlRequest
+            authorizationRequest = dcqlRequest,
+            dispatchInfo = dispatchInfoFor(request = dcqlRequest)
         )
 
         assertEquals(mapOf("mixed_dcql" to "success"), result)
@@ -2499,10 +2518,9 @@ class AuthorizationResponseHandlerTest {
         val capturedResponse = slot<AuthorizationResponse>()
         every {
             mockResponseHandler.getAuthorizationResponse(
-                authorizationRequest = any(),
+                dispatchInfo = any(),
                 authorizationResponse = capture(capturedResponse),
-                walletNonce = any<String>(),
-                walletConfig = any()
+                authorizationRequest = any()
             )
         } returns mapOf("no_state" to "response")
 
@@ -2515,7 +2533,8 @@ class AuthorizationResponseHandlerTest {
 
         authorizationResponseHandler.constructVPResponse(
             vpTokenSigningResults = signingResults,
-            authorizationRequest = dcqlRequest
+            authorizationRequest = dcqlRequest,
+            dispatchInfo = dispatchInfoFor(request = dcqlRequest)
         )
 
         assertNull(capturedResponse.captured.state)
@@ -2563,7 +2582,8 @@ class AuthorizationResponseHandlerTest {
         val exception = assertFailsWith<AuthorizationResponseConstructionFailure> {
             authorizationResponseHandler.constructVPResponse(
                 vpTokenSigningResults = signingResults,
-                authorizationRequest = dcqlRequest
+                authorizationRequest = dcqlRequest,
+                dispatchInfo = dispatchInfoFor(request = dcqlRequest)
             )
         }
         assertEquals("server_error", exception.errorCode)
@@ -2603,7 +2623,8 @@ class AuthorizationResponseHandlerTest {
         assertFailsWith<Exception> {
             authorizationResponseHandler.constructVPResponse(
                 vpTokenSigningResults = signingResults,
-                authorizationRequest = dcqlRequest
+                authorizationRequest = dcqlRequest,
+                dispatchInfo = dispatchInfoFor(request = dcqlRequest)
             )
         }
     }
@@ -2625,13 +2646,7 @@ class AuthorizationResponseHandlerTest {
         )
 
         every {
-            mockResponseHandler.sendAuthorizationResponse(
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
+            mockResponseHandler.sendAuthorizationResponse(any(), any(), any())
         } returns NetworkResponse(
             200,
             "{\"redirect_uri\":\"https://verifier.com/callback\"}",
@@ -2645,7 +2660,7 @@ class AuthorizationResponseHandlerTest {
         val result = authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest = dcqlRequest,
             vpTokenSigningResults = signingResults,
-            responseUri = responseUrl
+            dispatchInfo = dispatchInfoFor(request = dcqlRequest, responseUrl = responseUrl)
         )
 
         assertNotNull(result)

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerV1Test.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerV1Test.kt
@@ -32,7 +32,7 @@ class AuthorizationResponseHandlerV1Test {
         mockkObject(AuthorizationRequest)
         openID4VP = OpenID4VP("response-handler-v1-test")
         openID4VP.authorizationRequest = authorizationPresentationExchangeRequest
-        setField(openID4VP, "responseUri", responseUrl)
+        setField(openID4VP, "responseDispatchInfo", testDispatchInfo(responseUrl))
         setField(openID4VP, "walletNonce", "test-wallet-nonce")
     }
 
@@ -91,12 +91,12 @@ class AuthorizationResponseHandlerV1Test {
 
         val innerException = OpenID4VPExceptions.InvalidData("bad signing result", "test")
         every {
-            mockHandler.constructVPResponse(any(), any())
+            mockHandler.constructVPResponse(any(), any(), any())
         } throws OpenID4VPExceptions.AuthorizationResponseConstructionFailure(innerException, "test")
 
         val capturedEx = slot<Exception>()
         every {
-            mockHandler.constructAuthorizationErrorResponse(any(), capture(capturedEx), any())
+            mockHandler.constructAuthorizationErrorResponse(any(), capture(capturedEx), any(), any())
         } returns mapOf("error" to "server_error", "error_description" to "The wallet encountered an internal error while preparing the authorization response.")
 
         val result = openID4VP.constructVPResponse(emptyList())
@@ -117,7 +117,7 @@ class AuthorizationResponseHandlerV1Test {
         setField(openID4VP, "authorizationResponseHandler", mockHandler)
 
         every {
-            mockHandler.constructVPResponse(any(), any())
+            mockHandler.constructVPResponse(any(), any(), any())
         } returns mapOf(
             "vp_token" to "signed-vp-token",
             "presentation_submission" to "{...}",
@@ -201,7 +201,7 @@ class AuthorizationResponseHandlerV1Test {
         setField(openID4VP, "authorizationResponseHandler", mockHandler)
 
         every {
-            mockHandler.constructAuthorizationErrorResponse(any(), any(), any())
+            mockHandler.constructAuthorizationErrorResponse(any(), any(), any(), any())
         } returns mapOf(
             "error" to "invalid_request",
             "error_description" to "Missing nonce",

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostJwtResponseModeHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostJwtResponseModeHandlerTest.kt
@@ -23,6 +23,8 @@ import io.mosip.openID4VP.exceptions.OpenID4VPExceptions.*
 import io.mosip.openID4VP.jwt.jwe.JWEHandler
 import io.mosip.openID4VP.networkManager.NetworkManagerClient
 import io.mosip.openID4VP.networkManager.NetworkResponse
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
+import io.mosip.openID4VP.responseModeHandler.ResponseEncryptionSpecification
 import io.mosip.openID4VP.testData.authorizationRequestForResponseModeJWT
 import io.mosip.openID4VP.testData.authorizationResponse
 import io.mosip.openID4VP.testData.clientMetadataString
@@ -31,6 +33,27 @@ import org.junit.Test
 import kotlin.test.*
 
 class DirectPostJwtResponseModeHandlerTest {
+
+    private fun encryptionSpec(): ResponseEncryptionSpecification =
+        DirectPostJwtResponseModeHandler().validate(
+            deserializeAndValidate(clientMetadataString, ClientMetadataDraft23Serializer),
+            walletConfig,
+            false
+        )
+
+    private fun dispatchInfoFor(
+        responseUrl: String = "https://mock-verifier.com/response",
+        walletNonce: String = "walletNonce",
+        encryptionSpecification: ResponseEncryptionSpecification? = encryptionSpec()
+    ) = ResponseDispatchInfo(
+        responseMode = "direct_post.jwt",
+        nonce = authorizationRequestForResponseModeJWT.nonce,
+        walletNonce = walletNonce,
+        state = authorizationRequestForResponseModeJWT.state,
+        clientId = authorizationRequestForResponseModeJWT.clientId,
+        responseUrl = responseUrl,
+        responseEncryptionSpecification = encryptionSpecification
+    )
 
     @BeforeTest
     fun setUp() {
@@ -381,11 +404,9 @@ class DirectPostJwtResponseModeHandlerTest {
         every { anyConstructed<JWEHandler>().generateEncryptedResponse(any()) } returns "eytyiewr.....jewjr"
 
         val actualResponse = DirectPostJwtResponseModeHandler().sendAuthorizationResponse(
-            authorizationRequestForResponseModeJWT,
-            responseUri,
+            dispatchInfoFor(responseUri),
             authorizationResponse,
-            "walletNonce",
-            walletConfig = walletConfig
+            authorizationRequestForResponseModeJWT
         )
 
         verify {
@@ -410,10 +431,9 @@ class DirectPostJwtResponseModeHandlerTest {
         every { anyConstructed<JWEHandler>().generateEncryptedResponse(any()) } returns expectedEncryptedResponse
 
         val result = DirectPostJwtResponseModeHandler().getAuthorizationResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             authorizationResponse,
-            walletNonce,
-            walletConfig
+            authorizationRequestForResponseModeJWT
         )
 
         assertEquals(mapOf("response" to expectedEncryptedResponse), result)
@@ -431,10 +451,9 @@ class DirectPostJwtResponseModeHandlerTest {
         every { anyConstructed<JWEHandler>().generateEncryptedResponse(any()) } returns expectedEncryptedResponse
 
         val result = DirectPostJwtResponseModeHandler().getAuthorizationResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             authorizationResponse,
-            walletNonce,
-            walletConfig
+            authorizationRequestForResponseModeJWT
         )
 
         verify {
@@ -445,8 +464,35 @@ class DirectPostJwtResponseModeHandlerTest {
     }
 
     @Test
-    fun `getAuthorizationErrorResponse should not encrypt AuthorizationErrorResponse successfully`() {
-        val walletNonce = "error-wallet-nonce"
+    fun `getAuthorizationErrorResponse should encrypt AuthorizationErrorResponse when encryption is configured`() {
+        val errorResponse = AuthorizationErrorResponse(
+            error = "invalid_request",
+            errorDescription = "Test error description",
+            state = "test-state"
+        )
+        val encryptedError = "encrypted.error.jwe"
+        every { anyConstructed<JWEHandler>().generateEncryptedResponse(any()) } returns encryptedError
+
+        val result = DirectPostJwtResponseModeHandler().getAuthorizationErrorResponse(
+            dispatchInfoFor(),
+            errorResponse,
+            authorizationRequestForResponseModeJWT
+        )
+
+        assertEquals(mapOf("response" to encryptedError), result)
+        verify {
+            anyConstructed<JWEHandler>().generateEncryptedResponse(
+                match { params ->
+                    params["error"] == "invalid_request" &&
+                            params["error_description"] == "Test error description" &&
+                            params["state"] == "test-state"
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `getAuthorizationErrorResponse should return plain JSON when encryption is not configured`() {
         val errorResponse = AuthorizationErrorResponse(
             error = "invalid_request",
             errorDescription = "Test error description",
@@ -454,9 +500,9 @@ class DirectPostJwtResponseModeHandlerTest {
         )
 
         val result = DirectPostJwtResponseModeHandler().getAuthorizationErrorResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(encryptionSpecification = null),
             errorResponse,
-            walletNonce
+            authorizationRequestForResponseModeJWT
         )
 
         assertEquals(
@@ -476,10 +522,9 @@ class DirectPostJwtResponseModeHandlerTest {
         every { anyConstructed<JWEHandler>().generateEncryptedResponse(any()) } returns expectedEncryptedResponse
 
         val result = DirectPostJwtResponseModeHandler().getAuthorizationResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             authorizationResponse,
-            walletNonce,
-            walletConfig
+            authorizationRequestForResponseModeJWT
         )
 
         verify {
@@ -496,10 +541,9 @@ class DirectPostJwtResponseModeHandlerTest {
         every { anyConstructed<JWEHandler>().generateEncryptedResponse(any()) } returns expectedEncryptedResponse
 
         DirectPostJwtResponseModeHandler().getAuthorizationResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             authorizationResponse,
-            walletNonce,
-            walletConfig
+            authorizationRequestForResponseModeJWT
         )
 
         verify {
@@ -514,8 +558,7 @@ class DirectPostJwtResponseModeHandlerTest {
     }
 
     @Test
-    fun `getAuthorizationErrorResponse should handle AuthorizationErrorResponse with null state`() {
-        val walletNonce = "null-state-nonce"
+    fun `getAuthorizationErrorResponse should omit null state in plain JSON error response`() {
         val errorResponse = AuthorizationErrorResponse(
             error = "invalid_grant",
             errorDescription = "Invalid grant provided",
@@ -523,9 +566,9 @@ class DirectPostJwtResponseModeHandlerTest {
         )
 
         val result = DirectPostJwtResponseModeHandler().getAuthorizationErrorResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(encryptionSpecification = null),
             errorResponse,
-            walletNonce
+            authorizationRequestForResponseModeJWT
         )
 
         assertEquals(mapOf(
@@ -542,10 +585,9 @@ class DirectPostJwtResponseModeHandlerTest {
         every { anyConstructed<JWEHandler>().generateEncryptedResponse(any()) } returns encryptedContent
 
         val result = DirectPostJwtResponseModeHandler().getAuthorizationResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             authorizationResponse,
-            walletNonce,
-            walletConfig
+            authorizationRequestForResponseModeJWT
         )
 
         assertEquals(1, result.size)
@@ -597,36 +639,45 @@ class DirectPostJwtResponseModeHandlerTest {
 
     @Test
     fun `getAuthorizationResponse should encrypt response for V1 authorization request`() {
-        val request = createV1AuthorizationRequest(
-            clientMetadata = ClientMetadata(
-                vpFormatsSupported = mapOf(
-                    FormatType.LDP_VC.value to LdpVpFormatSupported(
-                        proofTypeValues = listOf(ProofType.Ed25519Signature2020)
-                    )
-                ),
-                encryptedResponseEncValuesSupported = listOf("A256GCM"),
-                jwks = Jwks(
-                    keys = listOf(
-                        Jwk(
-                            kty = "OKP",
-                            crv = "X25519",
-                            use = "enc",
-                            x = "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
-                            alg = "ECDH-ES",
-                            kid = "enc-key-v1"
-                        )
+        val clientMetadata = ClientMetadata(
+            vpFormatsSupported = mapOf(
+                FormatType.LDP_VC.value to LdpVpFormatSupported(
+                    proofTypeValues = listOf(ProofType.Ed25519Signature2020)
+                )
+            ),
+            encryptedResponseEncValuesSupported = listOf("A256GCM"),
+            jwks = Jwks(
+                keys = listOf(
+                    Jwk(
+                        kty = "OKP",
+                        crv = "X25519",
+                        use = "enc",
+                        x = "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
+                        alg = "ECDH-ES",
+                        kid = "enc-key-v1"
                     )
                 )
             )
         )
+        val request = createV1AuthorizationRequest(clientMetadata = clientMetadata)
 
         every { anyConstructed<JWEHandler>().generateEncryptedResponse(any()) } returns "v1.encrypted.response"
 
+        val encryptionSpecification =
+            DirectPostJwtResponseModeHandler().validate(clientMetadata, walletConfig, false)
+        val dispatchInfo = ResponseDispatchInfo(
+            responseMode = "direct_post.jwt",
+            nonce = request.nonce,
+            walletNonce = "wallet-nonce-v1",
+            state = request.state,
+            clientId = request.clientId,
+            responseUrl = "https://mock-verifier.com/response",
+            responseEncryptionSpecification = encryptionSpecification
+        )
         val result = DirectPostJwtResponseModeHandler().getAuthorizationResponse(
-            request,
+            dispatchInfo,
             authorizationResponse,
-            "wallet-nonce-v1",
-            walletConfig
+            request
         )
 
         assertEquals(mapOf("response" to "v1.encrypted.response"), result)

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostResponseModeHandlerTest.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/responseModeHandler/types/DirectPostResponseModeHandlerTest.kt
@@ -9,12 +9,22 @@ import io.mosip.openID4VP.authorizationResponse.toJsonEncodedMap
 import io.mosip.openID4VP.constants.ContentType
 import io.mosip.openID4VP.constants.HttpMethod
 import io.mosip.openID4VP.networkManager.NetworkManagerClient
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
 import io.mosip.openID4VP.testData.authorizationRequestForResponseModeJWT
 import io.mosip.openID4VP.testData.authorizationResponse
 import io.mosip.openID4VP.testData.walletConfig
 import kotlin.test.*
 
 class DirectPostResponseModeHandlerTest {
+
+    private fun dispatchInfoFor(responseUrl: String = "https://example.com/response") = ResponseDispatchInfo(
+        responseMode = "direct_post",
+        nonce = authorizationRequestForResponseModeJWT.nonce,
+        walletNonce = "test-nonce",
+        state = authorizationRequestForResponseModeJWT.state,
+        clientId = authorizationRequestForResponseModeJWT.clientId,
+        responseUrl = responseUrl
+    )
 
     @BeforeTest
     fun setUp() {
@@ -38,7 +48,6 @@ class DirectPostResponseModeHandlerTest {
     fun `sendAuthorizationResponse should send request and return response body`() {
         val handler = DirectPostResponseModeHandler()
         val responseUri = "https://example.com/response"
-        val walletNonce = "test-nonce"
         val expectedResponse = "Response received"
 
         every {
@@ -51,11 +60,9 @@ class DirectPostResponseModeHandlerTest {
         } returns io.mosip.openID4VP.networkManager.NetworkResponse(200, expectedResponse, emptyMap())
 
         val actualResponse = handler.sendAuthorizationResponse(
-            authorizationRequestForResponseModeJWT,
-            responseUri,
+            dispatchInfoFor(responseUri),
             authorizationResponse,
-            walletNonce,
-            walletConfig
+            authorizationRequestForResponseModeJWT
         )
 
         verify {
@@ -73,7 +80,6 @@ class DirectPostResponseModeHandlerTest {
     fun `sendAuthorizationResponse should handle network errors`() {
         val handler = DirectPostResponseModeHandler()
         val responseUri = "https://example.com/response"
-        val walletNonce = "test-nonce"
 
         every {
             NetworkManagerClient.sendHTTPRequest(
@@ -86,11 +92,9 @@ class DirectPostResponseModeHandlerTest {
 
         val exception = assertFailsWith<java.io.IOException> {
             handler.sendAuthorizationResponse(
-                authorizationRequestForResponseModeJWT,
-                responseUri,
+                dispatchInfoFor(responseUri),
                 authorizationResponse,
-                walletNonce,
-            walletConfig
+                authorizationRequestForResponseModeJWT
             )
         }
 
@@ -101,7 +105,6 @@ class DirectPostResponseModeHandlerTest {
     fun `sendAuthorizationResponse should handle empty response`() {
         val handler = DirectPostResponseModeHandler()
         val responseUri = "https://example.com/response"
-        val walletNonce = "test-nonce"
 
         every {
             NetworkManagerClient.sendHTTPRequest(
@@ -113,11 +116,9 @@ class DirectPostResponseModeHandlerTest {
         } returns io.mosip.openID4VP.networkManager.NetworkResponse(200, "", emptyMap())
 
         val actualResponse = handler.sendAuthorizationResponse(
-            authorizationRequestForResponseModeJWT,
-            responseUri,
+            dispatchInfoFor(responseUri),
             authorizationResponse,
-            walletNonce,
-            walletConfig
+            authorizationRequestForResponseModeJWT
         )
 
         assertEquals("", actualResponse.body)
@@ -127,13 +128,11 @@ class DirectPostResponseModeHandlerTest {
     @Test
     fun `getAuthorizationResponse should return JSON encoded map for AuthorizationResponse`() {
         val handler = DirectPostResponseModeHandler()
-        val walletNonce = "test-wallet-nonce"
-        
+
         val result = handler.getAuthorizationResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             authorizationResponse,
-            walletNonce,
-            walletConfig
+            authorizationRequestForResponseModeJWT
         )
 
         val expectedMap = authorizationResponse.toJsonEncodedMap()
@@ -143,17 +142,16 @@ class DirectPostResponseModeHandlerTest {
     @Test
     fun `getAuthorizationErrorResponse should return JSON encoded map for AuthorizationErrorResponse`() {
         val handler = DirectPostResponseModeHandler()
-        val walletNonce = "error-wallet-nonce"
         val errorResponse = AuthorizationErrorResponse(
             error = "invalid_request",
             errorDescription = "Test error description",
             state = "test-state"
         )
-        
+
         val result = handler.getAuthorizationErrorResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             errorResponse,
-            walletNonce
+            authorizationRequestForResponseModeJWT
         )
 
         val expectedMap = errorResponse.toJsonEncodedMap()
@@ -163,19 +161,17 @@ class DirectPostResponseModeHandlerTest {
     @Test
     fun `getAuthorizationResponse should handle AuthorizationResponse with all fields`() {
         val handler = DirectPostResponseModeHandler()
-        val walletNonce = "full-response-nonce"
-        
+
         val result = handler.getAuthorizationResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             authorizationResponse,
-            walletNonce,
-            walletConfig
+            authorizationRequestForResponseModeJWT
         )
 
         // Verify the result contains expected keys
         assertTrue(result.containsKey("vp_token"))
         assertTrue(result.containsKey("presentation_submission"))
-        
+
         // Verify the values are properly JSON encoded strings
         assertNotNull(result["vp_token"])
         assertNotNull(result["presentation_submission"])
@@ -184,17 +180,16 @@ class DirectPostResponseModeHandlerTest {
     @Test
     fun `getAuthorizationErrorResponse should handle AuthorizationErrorResponse with null state`() {
         val handler = DirectPostResponseModeHandler()
-        val walletNonce = "null-state-nonce"
         val errorResponse = AuthorizationErrorResponse(
             error = "access_denied",
             errorDescription = "Access denied",
             state = null
         )
-        
+
         val result = handler.getAuthorizationErrorResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             errorResponse,
-            walletNonce
+            authorizationRequestForResponseModeJWT
         )
 
         val expectedMap = errorResponse.toJsonEncodedMap()
@@ -208,8 +203,7 @@ class DirectPostResponseModeHandlerTest {
     @Test
     fun `getAuthorizationErrorResponse should handle different error types`() {
         val handler = DirectPostResponseModeHandler()
-        val walletNonce = "error-types-nonce"
-        
+
         val errors = listOf(
             "invalid_request" to "The request is missing a required parameter",
             "invalid_client" to "Client authentication failed",
@@ -225,11 +219,11 @@ class DirectPostResponseModeHandlerTest {
                 errorDescription = errorDescription,
                 state = "test-state-$errorCode"
             )
-            
+
             val result = handler.getAuthorizationErrorResponse(
-                authorizationRequestForResponseModeJWT,
+                dispatchInfoFor(),
                 errorResponse,
-                walletNonce
+                authorizationRequestForResponseModeJWT
             )
 
             assertEquals(errorResponse.toJsonEncodedMap(), result)
@@ -240,21 +234,19 @@ class DirectPostResponseModeHandlerTest {
     }
 
     @Test
-    fun `getAuthorizationResponse should ignore walletNonce parameter for AuthorizationResponse`() {
+    fun `getAuthorizationResponse should be independent of dispatch nonce for AuthorizationResponse`() {
         val handler = DirectPostResponseModeHandler()
-        
+
         val result1 = handler.getAuthorizationResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             authorizationResponse,
-            "nonce1",
-            walletConfig
+            authorizationRequestForResponseModeJWT
         )
-        
+
         val result2 = handler.getAuthorizationResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             authorizationResponse,
-            "nonce2",
-            walletConfig
+            authorizationRequestForResponseModeJWT
         )
 
         assertEquals(result1, result2)
@@ -263,24 +255,24 @@ class DirectPostResponseModeHandlerTest {
     }
 
     @Test
-    fun `getAuthorizationErrorResponse should ignore walletNonce parameter for AuthorizationErrorResponse`() {
+    fun `getAuthorizationErrorResponse should be independent of dispatch nonce for AuthorizationErrorResponse`() {
         val handler = DirectPostResponseModeHandler()
         val errorResponse = AuthorizationErrorResponse(
             error = "server_error",
             errorDescription = "Internal server error",
             state = "test-state"
         )
-        
+
         val result1 = handler.getAuthorizationErrorResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             errorResponse,
-            "nonce1"
+            authorizationRequestForResponseModeJWT
         )
-        
+
         val result2 = handler.getAuthorizationErrorResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             errorResponse,
-            "nonce2"
+            authorizationRequestForResponseModeJWT
         )
 
         assertEquals(result1, result2)
@@ -291,13 +283,11 @@ class DirectPostResponseModeHandlerTest {
     @Test
     fun `getAuthorizationResponse should return map with string values only`() {
         val handler = DirectPostResponseModeHandler()
-        val walletNonce = "string-values-nonce"
-        
+
         val result = handler.getAuthorizationResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             authorizationResponse,
-            walletNonce,
-            walletConfig
+            authorizationRequestForResponseModeJWT
         )
 
         assertTrue(result is Map<*, *>, "Result should be a Map")
@@ -316,17 +306,16 @@ class DirectPostResponseModeHandlerTest {
     @Test
     fun `getAuthorizationErrorResponse should return map with string values for error response`() {
         val handler = DirectPostResponseModeHandler()
-        val walletNonce = "error-string-values-nonce"
         val errorResponse = AuthorizationErrorResponse(
             error = "invalid_request",
             errorDescription = "Test error",
             state = "test-state"
         )
-        
+
         val result = handler.getAuthorizationErrorResponse(
-            authorizationRequestForResponseModeJWT,
+            dispatchInfoFor(),
             errorResponse,
-            walletNonce
+            authorizationRequestForResponseModeJWT
         )
 
         assertTrue(result is Map<*, *>, "Result should be a Map")

--- a/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/testData/TestUtils.kt
+++ b/kotlin/openID4VP/src/commonTest/kotlin/io/mosip/openID4VP/testData/TestUtils.kt
@@ -42,6 +42,19 @@ fun setField(instance: Any, fieldName: String, value: Any?) {
     field.set(instance, value)
 }
 
+fun testDispatchInfo(
+    responseUrl: String = "https://mock-verifier.com/response-uri",
+    responseMode: String = "direct_post",
+    state: String? = "fsnC8ixCs6mWyV+00k23Qg=="
+) = io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo(
+    responseMode = responseMode,
+    nonce = "bMHvX1HGhbh8zqlSWf/fuQ==",
+    walletNonce = "VbRRB/LTxLiXmVNZuyMO8A==",
+    state = state,
+    clientId = "https://mock-verifier.com",
+    responseUrl = responseUrl
+)
+
 fun createUrlEncodedData(
     requestParams: Map<String, String?>,
     verifierSentAuthRequestByReference: Boolean? = false,

--- a/kotlin/openID4VP/src/jvmTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthRequestByReferenceTest.kt
+++ b/kotlin/openID4VP/src/jvmTest/kotlin/io/mosip/openID4VP/authorizationRequest/AuthRequestByReferenceTest.kt
@@ -1,5 +1,7 @@
 package io.mosip.openID4VP.authorizationRequest
 
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
+
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
@@ -701,7 +703,7 @@ class AuthRequestByReferenceTest {
             AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 encodedAuthorizationRequest,
                 WalletConfig(trustedVerifiers = trustedVerifiers),
-                { _: String -> },
+                { _: ResponseDispatchInfo -> },
                 walletNonce
             )
         }

--- a/kotlin/openID4VP/src/jvmTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerJvmTest.kt
+++ b/kotlin/openID4VP/src/jvmTest/kotlin/io/mosip/openID4VP/authorizationResponse/AuthorizationResponseHandlerJvmTest.kt
@@ -5,6 +5,7 @@ import io.mosip.openID4VP.constants.FormatType
 import io.mosip.openID4VP.constants.FormatType.LDP_VC
 import io.mosip.openID4VP.constants.FormatType.MSO_MDOC
 import io.mosip.openID4VP.constants.SignatureSuiteAlgorithm.Ed25519Signature2018
+import io.mosip.openID4VP.responseModeHandler.ResponseDispatchInfo
 import io.mosip.openID4VP.testData.authorizationRequestForResponseModeJWT
 import io.mosip.openID4VP.testData.ldpCredential1
 import io.mosip.openID4VP.testData.sampleMdoc
@@ -35,10 +36,18 @@ class AuthorizationResponseHandlerJvmTest {
             nonce = "wallet-nonce-value",
         )
 
+        val dispatchInfo = ResponseDispatchInfo(
+            responseMode = authorizationRequest.responseMode!!,
+            nonce = authorizationRequest.nonce,
+            walletNonce = "wallet-nonce-value",
+            state = authorizationRequest.state,
+            clientId = authorizationRequest.clientId,
+            responseUrl = responseUri
+        )
         authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest = authorizationRequest,
             vpTokenSigningResults = vpTokenSigningResults,
-            responseUri = responseUri
+            dispatchInfo = dispatchInfo
         )
         assertFalse(true)
     }


### PR DESCRIPTION
Ports [inji-openid4vp-ios-swift#131](https://github.com/inji/inji-openid4vp-ios-swift/pull/131) to Kotlin.

Error responses in `direct_post.jwt` response mode were sent as plain JSON instead of an encrypted JWE. Both success and error responses must be returned using the supplied response mode.

Introduces `ResponseDispatchInfo` (with `ResponseEncryptionSpecification`), captured while validating the authorization request and threaded through response/error dispatch, so error responses are encrypted with the same specification as success responses.

Fixes https://github.com/inji/inji-wallet/issues/2484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved authorization response delivery across supported response modes.
  * Added support for response encryption based on verifier-provided settings.
  * Enhanced validation for direct-post and redirect-based requests.
* **Bug Fixes**
  * Invalid requests now follow the correct error-delivery behavior.
  * Errors that should not notify the verifier no longer trigger network requests.
  * Blank state values are omitted from error responses.
  * URL validation now supports valid encoded components and rejects malformed URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->